### PR TITLE
GOATS-53: Add htmlhint for GitHub Actions.

### DIFF
--- a/.github/workflows/run_flake8.yaml
+++ b/.github/workflows/run_flake8.yaml
@@ -1,7 +1,9 @@
 name: Run Flake8
 
 on:
-  - push
+  push:
+    paths:
+      - "**/*.py"
 
 jobs:
   run_flake8:

--- a/.github/workflows/run_htmlhint.yaml
+++ b/.github/workflows/run_htmlhint.yaml
@@ -1,0 +1,23 @@
+name: Run HTMLHint
+
+on:
+  push:
+    paths:
+      - "src/goats/tom_goats/templates/**/*.html"
+
+jobs:
+  run_htmlhint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+    - name: Install HTMLHint
+      run: npm install htmlhint -g
+
+    - name: Run HTMLHint
+      run: htmlhint src/goats/tom_goats/templates/**/*.html

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -2,8 +2,8 @@ name: Run Tests
 on:
   push:
     paths:
-      - "src/goats/**"
-      - "tests/unit/**"
+      - "src/goats/**/*.py"
+      - "tests/unit/**/*.py"
 
 jobs:
   run_tests:

--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,4 @@
+
+{
+    "doctype-first": false
+}

--- a/doc/changes/GOATS-53.other.md
+++ b/doc/changes/GOATS-53.other.md
@@ -1,0 +1,1 @@
+Optimized GitHub Actions and integrated HTML linting: GitHub Actions now operate selectively, with the HTML linter (`htmlhint`) triggered when template HTML files change, and unit tests and `flake8` checks run when Python files change. Additionally, common Jinja templating settings are now ignored by the HTML linter, thanks to the updated `htmlhint` configuration.


### PR DESCRIPTION
- Modify GitHub Action htmlhint runs on template html changes.
- Modify GitHub Action unit tests run on python changes.

[Jira Ticket](https://noirlab.atlassian.net/browse/GOATS-53)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.