### PR TITLE
GOATS-121: Implement observation and thumbnail deletion.

### DIFF
--- a/doc/changes/GOATS-121.new.md
+++ b/doc/changes/GOATS-121.new.md
@@ -1,0 +1,1 @@
+Added observation and thumbnail deletion: Added the ability to delete observations from a target and fixed a bug to correctly delete associated thumbnails from data products.

--- a/src/goats_tom/templates/tom_observations/observation_list.html
+++ b/src/goats_tom/templates/tom_observations/observation_list.html
@@ -1,0 +1,86 @@
+{% extends 'tom_common/base.html' %}
+{% load bootstrap4 observation_extras %}
+{% block title %}Observations{% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col-md-10">
+    <div class="row">
+      <div class="col-md-6">
+        {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+      </div>
+      <div class="col-md-6">
+        <span class="float-right">
+          {% update_status_button %}
+        </span>
+      </div>
+    </div>
+    {% observation_distribution filter.qs %}
+    <form action="" method="GET">
+    <div class="row">
+      <div class="col">
+        <button type="submit" name="action" value="add" class="btn btn-primary">Add</button>
+        <button type="submit" name="action" value="remove" class="btn btn-danger">Remove </button>
+        Selected observations from group
+        {{ filter.form.observationgroup }}
+      </div>
+    </div>
+
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Select</th>
+          <th>View</th>
+          <th>Target</th>
+          <th>Facility</th>
+          <th>Observation ID</th>
+          <th>Status</th>
+          <th>Start</th>
+          <th>End</th>
+          <th>Groups</th>
+          <th>Saved Data</th>
+          <th>Delete</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for observation in filter.qs %}
+        <tr>
+          <td><input type="checkbox" name="selected" value="{{observation.id}}"></td>
+          <td><a class="btn btn-success" href="{% url 'tom_observations:detail' observation.id %}">Details</a></td>
+          <td><a href="{% url 'tom_targets:detail' observation.target.id %}" title="{{ observation.target.id }}">{{ observation.target.names|join:", " }}</a></td>
+          <td>{{ observation.facility }}</td>
+          <td>{{ observation.observation_id }}</td>
+          <td>{{ observation.status }}</td>
+          <td>{{ observation.scheduled_start }}</td>
+          <td>{{ observation.scheduled_end }}</td>
+          <td>{% for o in observation.observationgroup_set.all %}{{ o.name }} {% endfor %}</td>
+          <td>{{ observation.dataproduct_set.count }}</td>
+          <td>
+            <a href="{% url 'delete' observation.id %}" title="Delete observation" class="btn btn-warning">Delete</a>
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="7">
+            No observations yet. You might want to create an observation from one of
+            <a href="{% url 'tom_targets:list' %}">your saved targets</a>.
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    </form>
+    {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
+  </div>
+  <div class="col-md-2">
+    <form action="" method="get" class="form">
+      {% bootstrap_form filter.form %}
+      {% buttons %}
+        <button type="submit" class="btn btn-primary">
+          Filter
+        </button>
+        <a href="{% url 'tom_observations:list' %}" class="btn btn-secondary" title="Reset">Reset</a>
+      {% endbuttons %}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/src/goats_tom/templates/tom_observations/observationrecord_confirm_delete.html
+++ b/src/goats_tom/templates/tom_observations/observationrecord_confirm_delete.html
@@ -1,0 +1,12 @@
+{% extends 'tom_common/base.html' %}
+{% load bootstrap4 %}
+{% block title %}Confirm delete{% endblock %}
+{% block content %}
+<h3>Confirm Delete</h3>
+<form method="post">{% csrf_token %}
+    <p>Are you sure you want to delete bservation ID {{ object.observation_id }} for target {{ object }}"?</p>
+    {% buttons %}
+    <button type="submit" class="btn btn-danger">Confirm</button>
+    {% endbuttons %}
+</form>
+{% endblock %}

--- a/src/goats_tom/urls.py
+++ b/src/goats_tom/urls.py
@@ -7,8 +7,10 @@ from tom_alerts.views import BrokerQueryListView
 # Local application/library specific imports.
 from . import views
 
+# TODO: Add app_name and update paths and URL lookups.
 
 urlpatterns = [
+    path('observations/<int:pk>/delete', views.ObservationRecordDeleteView.as_view(), name='delete'),
     path('targets/<int:pk>/', views.GOATSTargetDetailView.as_view(), name='detail'),
     path('observations/add/', views.GOATSAddExistingObservationView.as_view(), name='add-existing'),
     path("brokers/list/", BrokerQueryListView.as_view(), name="list"),

--- a/src/goats_tom/utils.py
+++ b/src/goats_tom/utils.py
@@ -1,0 +1,25 @@
+from tom_dataproducts.models import DataProduct, ReducedDatum
+from tom_observations.models import ObservationRecord
+
+
+def delete_associated_data_products(observation_record: ObservationRecord) -> None:
+    """Utility function to delete associated DataProducts.
+
+    Parameters
+    ----------
+    observation_record : `ObservationRecord`
+        The ObservationRecord object to find associated DataProducts.
+    """
+    query = DataProduct.objects.filter(observation_record=observation_record)
+    for data_product in query:
+        # Delete associated ReducedDatum objects.
+        ReducedDatum.objects.filter(data_product=data_product).delete()
+
+        # Delete the file from the disk.
+        data_product.data.delete()
+
+        # Delete thumbnail from the disk.
+        data_product.thumbnail.delete()
+
+        # Delete the `DataProduct` object from the database.
+        data_product.delete()


### PR DESCRIPTION
- Add functionality to delete observations from a target.
- Fix bug to correctly delete associated thumbnails from data products.

[Jira Ticket: GOATS-121](https://noirlab.atlassian.net/browse/GOATS-121)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.