### PR TITLE
GOATS-78: Enable editing of QueryBroker names from query list.

### DIFF
--- a/doc/changes/GOATS-78.new.md
+++ b/doc/changes/GOATS-78.new.md
@@ -1,0 +1,1 @@
+Allowed editing of query names in query list view.

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   },
   "scripts": {
     "test": "jest"
+  },
+  "dependencies": {
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/goats_tom/static/js/edit_brokerquery_name.js
+++ b/src/goats_tom/static/js/edit_brokerquery_name.js
@@ -1,0 +1,118 @@
+/**
+ * Initializes event listeners for in-place editing icons.
+ *
+ * This function attaches click event listeners to the containers of edit, save,
+ * and cancel icons. It ensures that these listeners remain effective even after
+ * Font Awesome replaces the inner `i` elements with `svg` elements.
+ */
+const initializeIconListeners = () => {
+  const table = document.getElementById("queryTable"); // Assuming the table has this ID
+
+  table.addEventListener("click", event => {
+    const container = event.target.closest("span");
+    if (!container) return;
+
+    const parentTd = container.closest("td");
+    if (container.classList.contains("edit-container")) {
+      enterEditMode(parentTd);
+    } else if (container.classList.contains("save-container")) {
+      saveChanges(parentTd);
+    } else if (container.classList.contains("cancel-container")) {
+      cancelEdit(parentTd);
+    }
+  });
+};
+
+/**
+ * Enters edit mode for a specific query row.
+ *
+ * @param {HTMLElement} container - The container element for the edit icon.
+ */
+const enterEditMode = (container) => {
+  let parentTd = container.closest("td");
+  toggleEditElements(parentTd, true);
+  let queryNameSpan = parentTd.querySelector(".query-name")
+  let queryNameAnchor = parentTd.querySelector(".query-name a");
+  let currentName = queryNameAnchor.textContent;
+
+  let inputElement = document.createElement("input");
+  inputElement.type = "text";
+  inputElement.className = "form-control edit-input mr-1";
+  inputElement.style.display = "inline-block";
+  inputElement.style.width = "auto";
+  inputElement.value = currentName;
+
+  queryNameAnchor.style.display = "none"; // Hide the anchor tag
+  queryNameSpan.after(inputElement); // Insert the input next to the anchor tag
+};
+
+/**
+ * Saves the changes made to the query name and updates the server asynchronously.
+ *
+ * @param {HTMLElement} container - The container element for the save icon.
+ */
+const saveChanges = async (container) => {
+  let parentTd = container.closest("td");
+  let newName = parentTd.querySelector(".edit-input").value;
+  let queryId = parentTd.querySelector(".query-name").dataset.id;
+
+  try {
+    const response = await fetch(`/alerts/query/${queryId}/update-name`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-CSRFToken": getCsrfToken()
+      },
+      body: `name=${encodeURIComponent(newName)}`
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("Success:", data);
+    // Update link text instead of replacing the entire link
+    let queryNameAnchor = parentTd.querySelector(".query-name a");
+    queryNameAnchor.textContent = newName;
+    queryNameAnchor.style.display = ""; // Show the anchor tag again
+  } catch (error) {
+    console.error("Error:", error);
+  } finally {
+    toggleEditElements(parentTd, false);
+    parentTd.querySelector(".edit-input").remove();
+  }
+};
+
+/**
+ * Cancels the edit operation and reverts any changes.
+ *
+ * @param {HTMLElement} container - The container element for the cancel icon.
+ */
+const cancelEdit = (container) => {
+  let parentTd = container.closest("td");
+  toggleEditElements(parentTd, false);
+  let queryNameAnchor = parentTd.querySelector(".query-name a");
+  queryNameAnchor.style.display = ""; // Show the anchor tag again
+
+  let inputElement = parentTd.querySelector(".edit-input");
+  if (inputElement) {
+    inputElement.remove();
+  }
+};
+
+/**
+ * Toggles the visibility of edit-related elements in the table row.
+ *
+ * @param {HTMLElement} parentTd - The parent TD element containing the icons.
+ * @param {boolean} isEditing - Flag indicating whether edit mode is active.
+ */
+const toggleEditElements = (parentTd, isEditing) => {
+  parentTd.querySelector(".query-name").style.display = isEditing ? "none" : "";
+  parentTd.querySelector(".edit-container").style.display = isEditing ? "none" : "";
+  parentTd.querySelector(".save-container").style.display = isEditing ? "inline" : "none";
+  parentTd.querySelector(".cancel-container").style.display = isEditing ? "inline" : "none";
+};
+
+// Initialize the event listeners when the DOM is fully loaded.
+document.addEventListener("DOMContentLoaded", initializeIconListeners);

--- a/src/goats_tom/static/js/get_csrf_token.js
+++ b/src/goats_tom/static/js/get_csrf_token.js
@@ -1,0 +1,12 @@
+/**
+* Retrieves the CSRF token from the cookies.
+*
+* Django sets a CSRF token in the cookies for the protection against CSRF
+* attacks. This function reads the CSRF token from the cookies and returns it.
+*
+* @return {string} The CSRF token.
+*/
+const getCsrfToken = () => {
+  const csrfToken = document.cookie.split('; ').find(row => row.startsWith('csrftoken='));
+  return csrfToken ? csrfToken.split('=')[1] : '';
+};

--- a/src/goats_tom/templates/tom_alerts/brokerquery_list.html
+++ b/src/goats_tom/templates/tom_alerts/brokerquery_list.html
@@ -1,0 +1,61 @@
+{% extends 'tom_common/base.html' %}
+{% load bootstrap4 static %}
+{% block title %}Query List{% endblock %}
+{% block content %}
+<h3>Query a Broker</h3>
+<div class="row">
+  <div class="col-md-10">
+    <p>
+      Create a new query using:
+      {% for broker in installed_brokers %}
+        <a href="{% url 'tom_alerts:create' %}?broker={{ broker }}" title="{{ broker }}" class="btn btn-outline-primary">{{ broker }}</a>
+      {% endfor %}
+    </p>
+    <table class="table table-striped">
+      <thead><tr><th>Name</th><th>Broker</th><th>Created</th><th>Last Run</th><th>Run</th><th>Delete</th></tr></thead>
+      <tbody id="queryTable">
+        {% for query in filter.qs %}
+        <tr>
+          <td>
+            <span class="query-name" data-id="{{ query.id }}"><a href="{% url 'tom_alerts:update' query.id %}" title="Update query" class="mr-1">{{ query.name }}</a></span>
+            <span class="edit-container">
+              <i class="fa-solid fa-pencil edit-icon" style="cursor: pointer;"></i>
+            </span>
+            <span class="save-container" style="display: none;">
+              <i class="fa-solid fa-check save-icon" style="cursor: pointer;"></i>
+            </span>
+            <span class="cancel-container" style="display: none;">
+              <i class="fa-solid fa-xmark cancel-icon" style="cursor: pointer;"></i>
+            </span>
+          </td>
+          <td>{{ query.broker }}</td>
+          <td>{{ query.created }}</td>
+          <td>{{ query.last_run }}</td>
+          <td><a href="{% url 'tom_alerts:run' query.id %}" title="Run query" class="btn btn-primary">Run</a></td>
+          <td><a href="{% url 'tom_alerts:delete' query.id %}" title="Delete query" class="btn btn-danger">Delete</a></td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="5">
+            No saved queries yet, Try creating a query from one of the alert brokers listed above.
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="col-md-2">
+    <h4>Filter Saved Queries</h4>
+    <form action="" method="get" class="form">
+      {% bootstrap_form filter.form %}
+      {% buttons %}
+        <button type="submit" class="btn btn-primary">
+          Filter
+        </button>
+        <a href="{% url 'tom_alerts:list' %}" class="btn btn-secondary" title="Reset">Reset</a>
+      {% endbuttons %}
+    </form>
+  </div>
+</div>
+<script src="{% static 'js/edit_brokerquery_name.js' %}"></script>
+{% endblock %}

--- a/src/goats_tom/templates/tom_common/base.html
+++ b/src/goats_tom/templates/tom_common/base.html
@@ -33,6 +33,7 @@
 
     {% block javascript %}
     <script src="{% static 'js/download_progress.js' %}"></script>
+    <script src="{% static 'js/get_csrf_token.js' %}"></script>
     {% endblock %}
 
     {% block extra_javascript %}{% endblock %}

--- a/src/goats_tom/urls.py
+++ b/src/goats_tom/urls.py
@@ -10,7 +10,9 @@ from . import views
 # TODO: Add app_name and update paths and URL lookups.
 # TODO: Make unified path formats.
 
-urlpatterns = [path("observations/<int:pk>/delete-data-products/", views.DeleteObservationDataProductsView.
+urlpatterns = [path("alerts/query/<int:pk>/update-name", views.update_brokerquery_name,
+                    name="update-brokerquery-name"),
+               path("observations/<int:pk>/delete-data-products/", views.DeleteObservationDataProductsView.
                     as_view(), name="delete-observation-data-products"),
                path("observations/<int:pk>/", views.GOATSObservationRecordDetailView.as_view(),
                     name="observation-detail"),

--- a/src/goats_tom/utils.py
+++ b/src/goats_tom/utils.py
@@ -1,6 +1,9 @@
-__all__ = ["delete_associated_data_products", "create_name_reduction_map", "custom_data_product_path"]
+__all__ = ["delete_associated_data_products", "create_name_reduction_map", "custom_data_product_path",
+           "build_json_response"]
 from astropy.table import Table
 
+from django.http import JsonResponse
+from rest_framework import status
 from tom_dataproducts.models import DataProduct, ReducedDatum
 from tom_observations.models import ObservationRecord
 
@@ -72,3 +75,26 @@ def custom_data_product_path(data_product: DataProduct, filename: str) -> str:
                 f"/{data_product.observation_record.observation_id}/{filename}")
     else:
         return f"{data_product.target.name}/none/none/{filename}"
+
+
+def build_json_response(error_message: str | None = None, error_status: int | None = status.HTTP_200_OK
+                        ) -> JsonResponse:
+    """Build a JSON response.
+
+    Parameters
+    ----------
+    error_message : `str`, optional
+        The error message to include in the response. If `None`, the response
+        indicates a successful operation.
+    error_status : `int`, optional
+        The HTTP status code for the response. Defaults to 200 (HTTP_200_OK).
+
+    Returns
+    -------
+    `JsonResponse`
+        A JSON response with either a success or error status.
+    """
+    if error_message:
+        return JsonResponse({"status": "error", "message": error_message}, status=error_status)
+
+    return JsonResponse({"status": "success", "message": ""}, status=error_status)


### PR DESCRIPTION
- Implement function to retrieve CSRF token for JavaScript operations.
- Add utility function for building JSON responses in fetch calls.

[Jira Ticket: GOATS-78](https://noirlab.atlassian.net/browse/GOATS-78)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.