### PR TITLE
GOATS-180: Extend error handling in OCSClient to return success status.

### DIFF
--- a/doc/changes/GOATS-180.new.md
+++ b/doc/changes/GOATS-180.new.md
@@ -1,0 +1,1 @@
+Extended error handling in OCSClient: The update introduces a dictionary return type for OCSClient methods, now including a 'success' key to clearly indicate the outcome of requests. Additionally, a 'return_raw_data' option has been implemented, allowing the inclusion of raw XML responses in the returned payload.

--- a/src/goats_tom/gemini.py
+++ b/src/goats_tom/gemini.py
@@ -585,7 +585,12 @@ class GOATSGEMFacility(BaseRoboticObservationFacility):
     def get_observation_status(self, observation_id):
         try:
             observation_summary = ocs_client.get_observation_summary(observation_id)
-            state = observation_summary["status"]
+
+            if not observation_summary["success"]:
+                raise Exception(f"{observation_summary['error']}")
+
+            state = observation_summary["data"]["status"]
+
         except Exception as e:
             logger.error(e)
             state = "Error"

--- a/src/goats_tom/ocs_client.py
+++ b/src/goats_tom/ocs_client.py
@@ -19,6 +19,14 @@ class OCSClient:
     This client provides methods to retrieve and parse observation sequence
     data and coordinates from the Gemini Observatory's databases.
 
+    Each method in this class returns a dictionary with the structure:
+    - success (bool): Indicates whether the request was successful.
+    - data (dict[str, Any] | None): Contains the parsed data if the request
+      was successful. Structure varies depending on the method.
+    - raw_data (str | None): Contains the raw XML data if 'return_raw_data'
+      is True.
+    - error (str | None): Contains the error message if the request failed.
+
     Attributes
     ----------
     method_names : `dict[str, str]`
@@ -72,142 +80,179 @@ class OCSClient:
             raise ValueError(f"Site not recognized in {site}")
         return f"{site_info['host']}:{site_info['port']}"
 
-    def _send_request(self, gemini_id: GeminiID, method_name: str | None = None) -> str:
+    def _send_request(
+        self, program_or_observation_id: str, method_name: str | None = None
+    ) -> dict[str, Any]:
         """Sends a request to the OCS server, handling both WDBA and ODB
         requests.
 
         Parameters
         ----------
-        gemini_id : `GeminiID`
-            The Gemini ID for which the request is being made.
+        program_or_observation_id : `str`
+            The program/observation ID for which the request is being made.
         method_name : `str | None`
             The name of the WDBA method to call, if this is a WDBA request.
 
         Returns
         -------
-        `str`
+        `dict[str, Any]`
             The response from the server.
 
         Raises
         ------
-        ValueError
+        Exception
             Raised if there's an error in the request.
         """
-        base_url = self._get_site_url(gemini_id.site)
+        try:
+            gemini_id = GeminiID(program_or_observation_id)
+            base_url = self._get_site_url(gemini_id.site)
 
-        if method_name is not None:
-            url = f"{base_url}{self.wdba_url}"
+            if method_name is not None:
+                url = f"{base_url}{self.wdba_url}"
 
-            # Bypass the expired certificate.
-            context = ssl._create_unverified_context()
+                # Bypass the expired certificate.
+                context = ssl._create_unverified_context()
 
-            # Get the method and call it.
-            with xmlrpc.client.ServerProxy(url, context=context) as proxy:
-                return getattr(proxy, method_name)(gemini_id.observation_id)
+                # Get the method and call it.
+                with xmlrpc.client.ServerProxy(url, context=context) as proxy:
+                    raw_data = getattr(proxy, method_name)(gemini_id.observation_id)
 
-        else:
+                return {"success": True, "raw_data": raw_data}
+
             full_url = f"{base_url}{self.odb_url}{gemini_id.program_id}"
 
             # Use verify=False to bypass expired certificate.
-            response = requests.get(full_url, verify=False, timeout=10)
+            response = requests.get(full_url, verify=False, timeout=3)
             response.raise_for_status()
-            return response.text
+            return {"success": True, "raw_data": response.text}
 
-    def _find_observation_summary(
-        self, parsed_response: dict[str, Any], observation_id: str
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def get_program_summary(
+        self, program_or_observation_id: str, return_raw_data: bool | None = False
     ) -> dict[str, Any]:
-        """Extracts a specific observation chunk from the parsed program data.
-
-        Parameters
-        ----------
-        parsed_response : `dict[str, Any]`
-            The parsed program data.
-        observation_id : `str`
-            The observation ID to search for.
-
-        Return
-        -------
-        `dict[str, Any]`
-            The observation data if found, otherwise an empty dictionary.
-        """
-        observations = parsed_response.get("observations", {}).get("observation", [])
-
-        # Search for matching observation ID.
-        for observation in observations:
-            if observation.get("id") == observation_id:
-                return observation
-
-        return {}
-
-    def get_program_summary(self, program_or_observation_id: str) -> dict[str, Any]:
         """Fetches summary for a program ID.
 
         Parameters
         ----------
         program_or_observation_id : `str`
             The program or observation ID.
+        return_raw_data : `bool | None`
+            Returns the raw XML data along with parsed data.
 
         Returns
         -------
         `dict[str, Any]`
             Program summary.
         """
-        gemini_id = GeminiID(program_or_observation_id)
-        response = self._send_request(gemini_id)
-        return self.parser.parse_odb_response(response)
+        response = self._send_request(program_or_observation_id)
+        if not response["success"]:
+            return response
+        response["data"] = self.parser.parse_odb_response(response["raw_data"])
 
-    def get_observation_summary(self, observation_id: str) -> dict[str, Any]:
+        if not return_raw_data:
+            del response["raw_data"]
+
+        return response
+
+    def get_observation_summary(
+        self, observation_id: str, return_raw_data: bool | None = False
+    ) -> dict[str, Any]:
         """Fetches summary for an observation ID.
 
         Parameters
         ----------
         observation_id : `str`
             The observation ID.
+        return_raw_data : `bool | None`
+            Returns the raw XML data along with parsed data.
 
         Returns
         -------
         `dict[str, Any]`
             Observation summary.
         """
-        gemini_id = GeminiID(observation_id)
-        response = self._send_request(gemini_id)
-        parsed_response = self.parser.parse_odb_response(response)
-        return self._find_observation_summary(parsed_response, gemini_id.observation_id)
+        response = self._send_request(observation_id)
+        if not response["success"]:
+            return response
+        parsed_response = self.parser.parse_odb_response(response["raw_data"])
 
-    def get_sequence(self, observation_id: str) -> dict[str, Any]:
+        if not return_raw_data:
+            del response["raw_data"]
+
+        observations = parsed_response.get("observations", {}).get("observation", [])
+
+        # Search for matching observation ID.
+        for observation in observations:
+            if observation.get("id") == observation_id:
+                response["data"] = observation
+                return response
+
+        # Return error if the observation ID is missing from the program ID.
+        gemini_id = GeminiID(observation_id)
+        return {
+            "success": False,
+            "error": (
+                f"Program '{gemini_id.program_id}' does not have observation "
+                f"'{gemini_id.observation_id}'"
+            ),
+        }
+
+    def get_sequence(
+        self, observation_id: str, return_raw_data: bool | None = False
+    ) -> dict[str, Any]:
         """Fetches the sequence data for a given observation ID.
 
         Parameters
         ----------
         observation_id : `str`
             The observation ID to query.
+        return_raw_data : `bool | None`
+            Returns the raw XML data along with parsed data.
 
         Returns
         -------
         `dict[str, Any]`
             The response from the server.
         """
-        gemini_id = GeminiID(observation_id)
         response = self._send_request(
-            gemini_id, method_name=self.method_names["get_sequence"]
+            observation_id, method_name=self.method_names["get_sequence"]
         )
-        return self.parser.parse_sequence_response(response)
+        if not response["success"]:
+            return response
+        response["data"] = self.parser.parse_sequence_response(response["raw_data"])
 
-    def get_coordinates(self, observation_id: str) -> dict[str, Any]:
+        if not return_raw_data:
+            del response["raw_data"]
+
+        return response
+
+    def get_coordinates(
+        self, observation_id: str, return_raw_data: bool | None = False
+    ) -> dict[str, Any]:
         """Fetches the coordinates for a given observation ID.
 
         Parameters
         ----------
         observation_id : `str`
             The observation ID to query.
+        return_raw_data : `bool | None`
+            Returns the raw XML data along with parsed data.
 
         Returns
         -------
         `dict[str, Any]`
             The response from the server.
         """
-        gemini_id = GeminiID(observation_id)
         response = self._send_request(
-            gemini_id, method_name=self.method_names["get_coordinates"]
+            observation_id, method_name=self.method_names["get_coordinates"]
         )
-        return self.parser.parse_coordinates_response(response)
+        if not response["success"]:
+            return response
+        response["data"] = self.parser.parse_coordinates_response(response["raw_data"])
+
+        if not return_raw_data:
+            del response["raw_data"]
+
+        return response

--- a/tests/unit/goats_tom/test_ocs_client.py
+++ b/tests/unit/goats_tom/test_ocs_client.py
@@ -47,6 +47,7 @@ def test_get_program_summary_with_observation_id(client, odb_xml, observation_id
 
     result = client.get_program_summary(observation_id)
     assert isinstance(result, dict)
+    assert result["success"]
 
 
 def test_get_program_summary_with_program_id(client, odb_xml, program_id):
@@ -55,6 +56,7 @@ def test_get_program_summary_with_program_id(client, odb_xml, program_id):
 
     result = client.get_program_summary(program_id)
     assert isinstance(result, dict)
+    assert result["success"]
 
 
 def test_get_observation_summary(client, odb_xml, observation_id):
@@ -63,6 +65,7 @@ def test_get_observation_summary(client, odb_xml, observation_id):
 
     result = client.get_observation_summary(observation_id)
     assert isinstance(result, dict)
+    assert result["success"]
 
 
 def test_get_sequence(client, sequence_xml, observation_id):
@@ -71,6 +74,7 @@ def test_get_sequence(client, sequence_xml, observation_id):
 
     result = client.get_sequence(observation_id)
     assert isinstance(result, dict)
+    assert result["success"]
 
 
 def test_get_coordinates(client, coordinates_xml, observation_id):
@@ -79,33 +83,39 @@ def test_get_coordinates(client, coordinates_xml, observation_id):
 
     result = client.get_coordinates(observation_id)
     assert isinstance(result, dict)
+    assert result["success"]
 
 
 @pytest.mark.remote_data
 def test_get_coordinates_remote(client, observation_id):
     coordinates_response = client.get_coordinates(observation_id)
-    assert coordinates_response
+    assert coordinates_response["data"]
+    assert coordinates_response["success"]
 
 
 @pytest.mark.remote_data
 def test_get_sequence_remote(client, observation_id):
     sequence_response = client.get_sequence(observation_id)
-    assert sequence_response
+    assert sequence_response["data"]
+    assert sequence_response["success"]
 
 
 @pytest.mark.remote_data
 def test_get_observation_summary_remote(client, observation_id):
     observation_id_response = client.get_observation_summary(observation_id)
-    assert observation_id_response
+    assert observation_id_response["data"]
+    assert observation_id_response["success"]
 
 
 @pytest.mark.remote_data
 def test_get_program_summary_with_observation_id_remote(client, observation_id):
     program_id_response = client.get_program_summary(observation_id)
-    assert program_id_response
+    assert program_id_response["data"]
+    assert program_id_response["success"]
 
 
 @pytest.mark.remote_data
 def test_get_program_summary_with_program_id_remote(client, program_id):
     program_id_response = client.get_program_summary(program_id)
-    assert program_id_response
+    assert program_id_response["data"]
+    assert program_id_response["success"]


### PR DESCRIPTION
- Add dictionary return type with 'success' key to indicate request outcome.
- Implement 'return_raw_data' option to include raw XML response in payload.

[Jira Ticket: GOATS-180](https://noirlab.atlassian.net/browse/GOATS-180)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.