### PR TITLE
GOATS-88: Add customizable address and port option.

### DIFF
--- a/doc/changes/GOATS-88.new.md
+++ b/doc/changes/GOATS-88.new.md
@@ -1,0 +1,1 @@
+Customizable server address and port: Users can now specify the address and port to run GOATS, accepting formats like '8000', '0.0.0.0:8000', or '192.168.1.5:8000'.

--- a/src/goats_setup/templates/goats_setup/settings.tmpl
+++ b/src/goats_setup/templates/goats_setup/settings.tmpl
@@ -26,7 +26,7 @@ SECRET_KEY = '{{ SECRET_KEY }}'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition


### PR DESCRIPTION
- Introduce a validator to ensure the addrport option follows the format "IP:PORT" or "PORT".
- Allow users to specify the address and port to serve GOATS.

[Jira Ticket: GOATS-88](https://noirlab.atlassian.net/browse/GOATS-88)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.