### PR TITLE
GOATS-216: Extend CLI for Redis server setup and concurrent running.

### DIFF
--- a/doc/changes/GOATS-216.new.md
+++ b/doc/changes/GOATS-216.new.md
@@ -1,0 +1,1 @@
+Extend CLI for Redis setup and running: Extended the `install` CLI to allow users to setup the Redis server. Modified the `run` CLI to run the Redis server in a separate thread alongside GOATS and Huey.

--- a/src/goats_setup/templates/goats_setup/settings.tmpl
+++ b/src/goats_setup/templates/goats_setup/settings.tmpl
@@ -120,7 +120,7 @@ CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [("localhost", 6379)],
+            "hosts": [("{{ REDIS_HOST }}", {{ REDIS_PORT }})],
         },
     },
 }
@@ -133,8 +133,8 @@ HUEY = {
     'immediate': False,  # If DEBUG=True, run synchronously.
     'utc': True,  # Use UTC for all times internally.
     'connection': {
-        'host': 'localhost',
-        'port': 6379,
+        'host': '{{ REDIS_HOST }}',
+        'port': {{ REDIS_PORT }},
         'db': 0,
         'connection_pool': None,
         'read_timeout': 1,  # If not polling (blocking pop), use timeout.


### PR DESCRIPTION
- Extend install CLI to facilitate Redis server setup.
- Modify run CLI to enable running Redis server in a separate thread alongside GOATS and Huey.

[Jira Ticket: GOATS-N](https://noirlab.atlassian.net/browse/GOATS-N)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.