### PR TITLE
GOATS-210 GOATS-222 GOATS-223: Incorporate DRAGONS into the GOATS stack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gemini Observation and Analysis of Targets System (GOATS)
+# 🐐 Gemini Observation and Analysis of Targets System (GOATS)
 
 [![Run Flake8](https://github.com/gemini-hlsw/goats/actions/workflows/run_flake8.yaml/badge.svg?branch=main&event=push)](https://github.com/gemini-hlsw/goats/actions/workflows/run_flake8.yaml)
 [![Run Tests](https://github.com/gemini-hlsw/goats/actions/workflows/run_tests.yaml/badge.svg?branch=main&event=push)](https://github.com/gemini-hlsw/goats/actions/workflows/run_tests.yaml)
@@ -16,52 +16,111 @@ Its objective is to simplify the TDAMM workflow for users by serving as a one-st
   title="Ecosystem of GOATS"
   style="display: inline-block; margin: 0 auto; max-width: 400px">
 
-## Installation
+## System Requirements
+- Python 3.10 or higher
+- Intel Anaconda or Miniconda (works on M1 architecture) >= 4.12
 
-```shell
+### Workaround for ARM (M1/M2) Mac users:
+- Ensure you have Rosetta 2 installed to run Intel-based binaries.
+- Install an x86 version of Anaconda or Miniconda.
+- You need to switch to an x86 terminal for installing and running Intel-only packages like DRAGONS.
+
+## Installation
+```console
 git clone https://github.com/gemini-hlsw/goats.git
 cd goats
+conda env create -f environment.yml
+conda activate goats-env
 pip install .
 ```
+This installs the `goats` CLI which can be used to install and run GOATS.
+```console
+goats install
+goats run
+```
 
-# GOATS CLI Guide
+To test:
+```console
+pip install '.[test]'
+pytest
+```
+
+
+## GOATS CLI
 
 The **Gemini Observation and Analysis of Targets System (GOATS)** CLI provides an efficient way to install and manage the GOATS project along with the antares2goats browser extension. You can get detailed help on each command using the `--help` option. Below, find the breakdown of the primary commands and options:
 
-## Getting Started
-
+### `goats`
 Use the following command to get an overview of available options and commands:
+```console
+$ goats --help
 
-`goats --help`
+Usage: goats [OPTIONS] COMMAND [ARGS]...
 
-### Available Commands
+  Gemini Observation and Analysis of Targets System (GOATS).
 
-1. `install`: Installs GOATS along with the optional antares2goats browser extension.
+  You can run each subcommand with its own options and arguments. For
+  details on a specific command, type 'goats COMMAND --help'.
 
-   `goats install [OPTIONS]`
+Options:
+  --help  Show this message and exit.
 
-   #### Options
-   - `-p, --project-name TEXT`: Specify a custom project name (default: 'GOATS').
-   - `-d, --directory PATH`: Specify the parent directory where GOATS will be installed (default: current directory).
-   - `--overwrite`: Overwrite the existing project, if it exists (default: False).
-   - `--browser [chrome|safari|firefox]`: Specify the browser for which to install the extension.
+Commands:
+  install  Installs GOATS and configures Redis server.
+  run      Starts the webserver, Redis server, and workers for GOATS.
+```
 
-   Get more information with:
+### `goats install`
+```console
+$ goats install --help
 
-   `goats install --help`
+Usage: goats install [OPTIONS]
 
-2. `run`: Starts the server for the GOATS project.
+  Installs GOATS and configures Redis Server.
 
-   `goats run [OPTIONS]`
+Options:
+  -p, --project-name TEXT  Specify a custom project name. Default is 'GOATS'.
+  -d, --directory PATH     Specify the parent directory where GOATS will be
+                           installed. Default is the current directory.
 
-   #### Options
-   - `-p, --project-name TEXT`: Specify a custom project name (default: 'GOATS').
-   - `-d, --directory PATH`: Specify the parent directory where GOATS is installed (default: current directory).
-   - `--reloader`: Runs the server with a reloader for active development.
+  --overwrite              Overwrite the existing project, if it exists.
+                           Default is False.
 
-   Get more information with:
+  -m, --media-dir PATH     Path for saving downloaded media.
+  --redis-addrport TEXT    Specify the Redis server IP address and port
+                           number. Examples: '6379', 'localhost:6379',
+                           '192.168.1.5:6379'. Providing only a port number
+                           (e.g., '6379') binds to localhost.
 
-   `goats run --help`
+  --help                   Show this message and exit.
+```
+
+### `goats run`
+```console
+$ goats run --help
+
+Usage: goats run [OPTIONS]
+
+  Starts the webserver, Redis server, and workers for GOATS.
+
+Options:
+  -p, --project-name TEXT  Specify a custom project name. Default is 'GOATS'.
+  -d, --directory PATH     Specify the parent directory where GOATS is
+                           installed. Default is the current directory.
+
+  -w, --workers INTEGER    Number of workers to spawn for background tasks.
+  --addrport TEXT          Specify the IP address and port number to serve
+                           GOATS. Examples: '8000', '0.0.0.0:8000',
+                           '192.168.1.5:8000'. Providing only a port number
+                           (e.g., '8000') binds to 127.0.0.1.
+
+  --redis-addrport TEXT    Specify the Redis server IP address and port
+                           number. Examples: '6379', 'localhost:6379',
+                           '192.168.1.5:6379'. Providing only a port number
+                           (e.g., '6379') binds to localhost.
+
+  --help                   Show this message and exit.
+```
 
 ## References and Documentation
 

--- a/doc/changes/GOATS-210.new.md
+++ b/doc/changes/GOATS-210.new.md
@@ -1,0 +1,1 @@
+DRAGONS integration and conda environment creation: DRAGONS is now part of the GOATS stack. A dedicated Conda environment file, `environment.yml`, is available for easy installation by users cloning the repository. Additionally, the stack now includes a Redis server to support the latest changes in GOATS infrastructure.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,35 @@
+# Environment configuration for GOATS (goats-env)
+
+# For ARM (M1/M2) Mac users:
+#  - Ensure you have Rosetta 2 installed to run Intel-based binaries.
+#  - Install an x86 version of Anaconda or Miniconda.
+#  - You need to switch to an x86 terminal for installing and running
+#    Intel-only packages like DRAGONS.
+
+# Creating the environment:
+# conda env create -f environment.yml
+
+name: goats-env
+
+channels:
+  - conda-forge
+  - http://astroconda.gemini.edu/public
+  - defaults
+
+dependencies:
+  - astropy<=5.3.0  # Required to be compatible with DRAGONS and Bokeh.
+  - dragons
+  - ds9
+  - bokeh=2.4.3  # Required due to astropy.
+  - python-confluent-kafka=1.7.0  # Required for linking librdkafka in conda.
+  - librdkafka>=1.7.0  # Required while antares-client upgrades kafka.
+  - pip
+  - python=3.10
+  - redis-server
+
+  # For development, use clone the GOATS repo and "pip install -e ." or
+  # for tests, install with "pip install -e '.[test]'".
+
+  # Uncomment the below lines to install from GitHub (requires repo access).
+  # - pip:
+  #   - git+https://github.com/gemini-hlsw/goats.git#branch=main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,18 +15,18 @@ classifiers = [
 ]
 requires-python = ">=3.10.0"
 dependencies = [
-    "tom-antares",
-    "tom-gemini-community",
+    "tom-antares==1.2.6",
     "tomtoolkit==2.15.19",
-    "click",
+    "click>=8.1.7",
     "werkzeug",
-    "django-cors-headers",
-    "huey>=2.5.0",
+    "django-cors-headers>=4.3.0",
+    "huey",
     "greenlet>=3.0.2",
-    "fontawesomefree==6.5.1",
+    "fontawesomefree>=6.5.0",
     "django-cryptography==1.1",
-    "channels[daphne]==4.0",
-    "channels_redis==4.2.0",
+    "channels[daphne]>=4.0",
+    "channels_redis>=4.0.0",
+    "django>=4,<5"
 ]
 
 version = "24.02.0"

--- a/src/goats_cli/cli.py
+++ b/src/goats_cli/cli.py
@@ -64,7 +64,7 @@ def cli(ctx):
         click.echo(ctx.get_help())
 
 
-@click.command(help=("Installs GOATS."))
+@click.command(help=("Installs GOATS and configures Redis server."))
 @click.option(
     "-p",
     "--project-name",
@@ -113,7 +113,7 @@ def install(
     redis_addrport: str,
 ) -> None:
     """Installs GOATS with a specified or default name in a specified or
-    default directory.
+    default directory and configures Redis server.
 
     Parameters
     ----------
@@ -216,7 +216,7 @@ def install(
         raise GOATSClickException(str(error))
 
 
-@click.command(help=("Starts the server and workers for GOATS."))
+@click.command(help=("Starts the webserver, Redis server, and workers for GOATS."))
 @click.option(
     "-p",
     "--project-name",
@@ -266,7 +266,7 @@ def install(
 def run(
     project_name: str, directory: Path, workers: int, addrport: str, redis_addrport: str
 ) -> None:
-    """Starts the server and workers for GOATS.
+    """Starts the webserver, Redis server, and workers for GOATS.
 
     Parameters
     ----------


### PR DESCRIPTION
- Add Conda environment file for easy installation.

[Jira Ticket: GOATS-210](https://noirlab.atlassian.net/browse/GOATS-210)
[Jira Ticket: GOATS-222](https://noirlab.atlassian.net/browse/GOATS-222)
[Jira Ticket: GOATS-223](https://noirlab.atlassian.net/browse/GOATS-223)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.