### PR TITLE
GOATS-209: Add toggle feature for enabling/disabling files in DRAGONS setup.

### DIFF
--- a/src/goats_tom/serializers/dragons_file.py
+++ b/src/goats_tom/serializers/dragons_file.py
@@ -69,6 +69,7 @@ class DRAGONSFileSerializer(serializers.ModelSerializer):
     class Meta:
         model = DRAGONSFile
         fields = [
+            "id",
             "dragons_run",
             "product_id",
             "observation_id",

--- a/src/goats_tom/static/css/cores/halfmoon.goats.css
+++ b/src/goats_tom/static/css/cores/halfmoon.goats.css
@@ -449,3 +449,8 @@ select.form-control[multiple] {
   margin-right: calc(-0.5 * var(--bs-offcanvas-padding-x));
   margin-bottom: calc(-0.5 * var(--bs-offcanvas-padding-y));
 }
+
+.accordian-overflow {
+  max-height: 200px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
- Implement checkbox functionality to enable or disable files for reduction runs.
- Add CSS class to restrict table size for handling large file lists.

[Jira Ticket: GOATS-209](https://noirlab.atlassian.net/browse/GOATS-209)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.