### PR TITLE
GOATS-257 GOATS-260: Filter bias files for run and bugfix.

### DIFF
--- a/doc/changes/GOATS-257.new.md
+++ b/doc/changes/GOATS-257.new.md
@@ -1,0 +1,1 @@
+Changed DRAGONS run initialization: Extended backend logic to disable all bias files outside a specified day range of the observations during the initialization of a DRAGONS run. Optimized number of database queries when creating a DRAGONS run.

--- a/doc/changes/GOATS-259.new.md
+++ b/doc/changes/GOATS-259.new.md
@@ -1,0 +1,1 @@
+Added DRAGONS recipes and primitives API v1: Implemented REST API endpoints for DRAGONS recipes and primitives. The system now includes serializers for filtering by query parameters. Models were structured to connect recipes with primitives, allowing users to enable or disable individual primitives. This version supports only default recipes.

--- a/src/goats_tom/static/js/dragons_setup_mvc.js
+++ b/src/goats_tom/static/js/dragons_setup_mvc.js
@@ -292,6 +292,11 @@ class SetupView {
     cellCheckbox.appendChild(label); // Appends the label right after the checkbox.
     row.appendChild(cellCheckbox);
 
+    // Build the additional data to display.
+    const cellObsDate = this.createElement("td", "py-0");
+    cellObsDate.textContent = file.observation_date;
+    row.appendChild(cellObsDate);
+
     return row;
   }
 


### PR DESCRIPTION
- Disable all bias files outside specified day range during initialization.
- Optimize database queries when creating a DRAGONS run.
- Correct bug introduced from last PR, is_enabled to enabled.

[Jira Ticket: GOATS-257](https://noirlab.atlassian.net/browse/GOATS-257)
[Jira Ticket: GOATS-260](https://noirlab.atlassian.net/browse/GOATS-260)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.