### PR TITLE
GOATS-247: Fix file count and duplicate entries.

### DIFF
--- a/doc/changes/GOATS-247.bugfix.md
+++ b/doc/changes/GOATS-247.bugfix.md
@@ -1,0 +1,1 @@
+Fixed file count and duplicate entries: Corrected the bug in the total file count calculation and prevented duplicates in the list of files downloaded to ensure an accurate count.

--- a/src/goats_tom/astroquery/gemini.py
+++ b/src/goats_tom/astroquery/gemini.py
@@ -752,6 +752,7 @@ class ObservationsClass(QueryWithLogin):
             download_info = self._generate_download_info(temp_dir)
 
             # Delete additional files if wanted.
+            # TODO Now that we have this in a temp directory, this does nothing.
             if remove_readme:
                 for file_name in ["README.txt", "md5sums.txt"]:
                     file_path = temp_dir / file_name

--- a/src/goats_tom/tasks/tasks.py
+++ b/src/goats_tom/tasks/tasks.py
@@ -75,7 +75,6 @@ def download_goa_files(serialized_observation_record, query_params, user: int):
 
     # Create blank mapping.
     name_reduction_map = {}
-    num_files_downloaded = 0
     num_files_omitted = 0
     try:
         sci_files = []
@@ -100,7 +99,6 @@ def download_goa_files(serialized_observation_record, query_params, user: int):
                 **kwargs,
             )
             sci_files = sci_out["downloaded_files"]
-            num_files_downloaded += sci_out["num_files_downloaded"]
             num_files_omitted += sci_out["num_files_omitted"]
 
         if not download_calibration == "no":
@@ -120,7 +118,6 @@ def download_goa_files(serialized_observation_record, query_params, user: int):
                 **calibration_kwargs,
             )
             cal_files = cal_out["downloaded_files"]
-            num_files_downloaded = cal_out["num_files_downloaded"]
             num_files_omitted += cal_out["num_files_omitted"]
 
         download_state.update_and_send(
@@ -138,7 +135,9 @@ def download_goa_files(serialized_observation_record, query_params, user: int):
         download.finish()
         return
 
-    downloaded_files = sci_files + cal_files
+    downloaded_files = set(sci_files + cal_files)
+    num_files_downloaded = len(downloaded_files)
+
     # Now lead by the files in the folder.
     for file_name in downloaded_files:
         file_path = target_facility_path / file_name


### PR DESCRIPTION
- Correct the bug in total file count calculation.
- Prevent duplicates in the list of files downloaded to ensure accuracy.

[Jira Ticket: GOATS-247](https://noirlab.atlassian.net/browse/GOATS-247)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.