### PR TITLE
GOATS-258: Enhance API file retrieval with header inclusion.

### DIFF
--- a/doc/changes/GOATS-258.new.md
+++ b/doc/changes/GOATS-258.new.md
@@ -1,0 +1,1 @@
+Enhanced file retrieval with header inclusion: Added a query parameter, `?include=header`, to include header information for files in DRAGONS runs.

--- a/src/goats_tom/serializers/dragons_file.py
+++ b/src/goats_tom/serializers/dragons_file.py
@@ -93,3 +93,6 @@ class DRAGONSFileSerializer(serializers.ModelSerializer):
 class DRAGONSFileFilterSerializer(serializers.Serializer):
     group_by_file_type = serializers.BooleanField(required=False, default=False)
     dragons_run = serializers.IntegerField(required=False)
+    include = serializers.ListField(
+        child=serializers.ChoiceField(choices=["header"]), required=False
+    )

--- a/src/goats_tom/utils/__init__.py
+++ b/src/goats_tom/utils/__init__.py
@@ -4,6 +4,7 @@ from .utils import (
     custom_data_product_path,
     delete_associated_data_products,
     extract_metadata,
+    get_astrodata_header,
     get_key,
     get_key_info,
     get_short_name,
@@ -20,4 +21,5 @@ __all__ = [
     "get_key_info",
     "extract_metadata",
     "get_short_name",
+    "get_astrodata_header",
 ]

--- a/src/goats_tom/utils/utils.py
+++ b/src/goats_tom/utils/utils.py
@@ -10,10 +10,12 @@ __all__ = [
     "get_key_info",
     "extract_metadata",
     "get_short_name",
+    "get_astrodata_header",
 ]
 
 import re
 from pathlib import Path
+from typing import Any
 
 import astrodata
 from astropy.table import Table
@@ -316,3 +318,29 @@ def get_short_name(name: str) -> str | None:
     if match:
         return match.group(1)
     return None
+
+
+def get_astrodata_header(data_product: DataProduct) -> dict[str, Any]:
+    """Gets the header information from astrodata.
+
+    Parameters
+    ----------
+    data_product : `DataProduct`
+        The data product to extract headers.
+
+    Returns
+    -------
+    `dict[str, Any]`
+        Header payload from astrodata.
+    """
+    ad = astrodata.open(data_product.data.path)
+    # Prepare the header information.
+    header = {}
+    for descriptor in ad.descriptors:
+        # Fetch the value of the descriptor.
+        value = getattr(ad, descriptor)()
+
+        # Append the descriptor data to the header list.
+        header[descriptor] = value
+
+    return header


### PR DESCRIPTION
- Add query parameter for header information in DRAGONS runs.
- Implement method to extract header using astrodata.

[Jira Ticket: GOATS-258](https://noirlab.atlassian.net/browse/GOATS-258)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.