### PR TITLE
GOATS-208: Link JS9 button to open file with JS9.

### DIFF
--- a/doc/changes/GOATS-208.bugfix.md
+++ b/doc/changes/GOATS-208.bugfix.md
@@ -1,0 +1,1 @@
+Fixed bug in JS9 to ensure correct color for labels.

--- a/doc/changes/GOATS-208.new.md
+++ b/doc/changes/GOATS-208.new.md
@@ -1,0 +1,1 @@
+Link JS9 button to open file with JS9: Extended the serializer to include data URL for JS9.

--- a/src/goats_tom/serializers/dragons_file.py
+++ b/src/goats_tom/serializers/dragons_file.py
@@ -42,6 +42,7 @@ class DRAGONSFileSerializer(serializers.ModelSerializer):
     observation_id = serializers.CharField(
         source="data_product.observation_record.observation_id"
     )
+    url = serializers.CharField(source="data_product.data.url")
     file_type = serializers.CharField(source="data_product.metadata.file_type")
     group_id = serializers.CharField(
         source="data_product.metadata.group_id", allow_null=True
@@ -72,6 +73,7 @@ class DRAGONSFileSerializer(serializers.ModelSerializer):
             "id",
             "dragons_run",
             "product_id",
+            "url",
             "observation_id",
             "file_type",
             "group_id",

--- a/src/goats_tom/static/css/cores/halfmoon.goats.css
+++ b/src/goats_tom/static/css/cores/halfmoon.goats.css
@@ -465,3 +465,17 @@ select.form-control[multiple] {
   font-family: monospace;
   height: 200px;
 }
+
+/* stylelint-disable */
+/* Fix for JS9 inheriting from parent. */
+.JS9Button {
+  font: normal 12px Arial;
+  background: #F6F6F6;
+  border: black 2px;
+  border-radius: 4px;
+  padding: 3px 6px;
+  margin: 6px 4px;
+  outline: none;
+  color: #4d494d;
+}
+/* stylelint-enable */

--- a/src/goats_tom/static/js/dragons_setup_mvc.js
+++ b/src/goats_tom/static/js/dragons_setup_mvc.js
@@ -377,10 +377,11 @@ class SetupView {
     button1.textContent = "Header";
     button1.dataset.fileId = file.id;
     const divider = Utils.createElement("hr", "dropdown-divider");
-    const button2 = Utils.createElement("button", "dropdown-item");
+    const button2 = Utils.createElement("button", ["dropdown-item", "js9-button"]);
     button2.setAttribute("type", "button");
     button2.setAttribute("aria-current", "true");
     button2.textContent = "JS9";
+    button2.dataset.url = file.url;
 
     li1.appendChild(button1);
     li2.appendChild(divider);
@@ -444,10 +445,14 @@ class SetupView {
     // Delegate for header button clicks.
     this.filesContainer.addEventListener("click", (event) => {
       if (event.target.classList.contains("header-button")) {
-        console.log("clickeD");
-        // Ensure your button has this class
         const fileId = event.target.dataset.fileId;
         this.onShowHeader(fileId);
+      }
+
+      if (event.target.classList.contains("js9-button")) {
+        console.log("js9");
+        const url = event.target.dataset.url;
+        openJS9Window(url);
       }
     });
   }

--- a/src/goats_tom/templates/dragons_index.html
+++ b/src/goats_tom/templates/dragons_index.html
@@ -1,6 +1,8 @@
 {% extends "tom_common/base.html" %}
+{% load static %}
 {% block content %}
 {% csrf_token %}
+
 <!-- Modal -->
 <div id="modalContainer"></div>
 
@@ -79,8 +81,20 @@
     <div id="recipesContainer" class="row g-3"></div>
   </div>
 </div>
+{% endblock %}
 
-<script>
+{% block javascript %}
+<script src="{% static 'js/utils.js' %}"></script>
+<script src="{% static 'js/logger.js' %}"></script>
+<script src="{% static 'js/get_csrf_token.js' %}"></script>
+<script src="{% static 'js/fetch_wrapper.js' %}"></script>
+<script src="{% static 'js/dragons_setup_mvc.js' %}"></script>
+<script src="{% static 'js/recipes_mvc.js' %}"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.33.2/ace.js" integrity="sha512-ppeKocqkhnGjdqlJqj3weg8YlLjWdnedZiCayzrfmQv/v/MoEMMxDXTwBK3CmoUv1oC1NCT2w4P8JnGETEft1w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+{% include 'tom_dataproducts/partials/js9_scripts.html' %}
+
+<script type="text/javascript">
   document.addEventListener("DOMContentLoaded", async () => {
     const api = new FetchWrapper("/api/");
     const recipesContainer = document.getElementById("recipesContainer");

--- a/src/goats_tom/templates/tom_common/base.html
+++ b/src/goats_tom/templates/tom_common/base.html
@@ -17,7 +17,7 @@
     <!-- JavaScript -->
     {% bootstrap_javascript jquery='True' %}
     <script src="{% static 'js/toggle_mode.js' %}"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.33.1/ace.js" integrity="sha512-WN1CEDE9Js0mEqvtRrNS7GHS+arRJxWVO03zttkQQXEQjwGVcHQ2kMja415m0bNeB3AtYsyjUWJ1BS4wGLta/Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
 
 
     <title>GOATS</title>
@@ -38,12 +38,6 @@
     <footer class="container-fluid py-4 bg-light-subtle">{% include 'footer.html' %}</footer>
 
     {% block javascript %}
-    <script src="{% static 'js/utils.js' %}"></script>
-    <script src="{% static 'js/logger.js' %}"></script>
-    <script src="{% static 'js/get_csrf_token.js' %}"></script>
-    <script src="{% static 'js/fetch_wrapper.js' %}"></script>
-    <script src="{% static 'js/dragons_setup_mvc.js' %}"></script>
-    <script src="{% static 'js/recipes_mvc.js' %}"></script>
     <script type="module">
       import { createAndShowToast } from "{% static 'js/toast_utils.js' %}";
       import { updateDownloadProgress } from "{% static 'js/download_progress.js' %}";


### PR DESCRIPTION
- Extend serializer to include data URL for JS9.
- Fix bug in JS9 to have correct color for labels.

[Jira Ticket: GOATS-208](https://noirlab.atlassian.net/browse/GOATS-208)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.