### PR TITLE
GOATS-250: Allow users to change the names of the DRAGONS setup files.

### DIFF
--- a/doc/changes/GOATS-250.change.md
+++ b/doc/changes/GOATS-250.change.md
@@ -1,0 +1,1 @@
+Allow changing DRAGONS setup files names: Users can now change the DRAGONS setup files names. Removed the ability to change the log file name and removed from form. Added helper functions to get the path of DRAGONS setup files.

--- a/src/goats_tom/models/dragons_run.py
+++ b/src/goats_tom/models/dragons_run.py
@@ -61,16 +61,12 @@ class DRAGONSRun(models.Model):
         max_length=255,
         blank=True,
     )
-    config_filename = models.CharField(
-        max_length=30, default="dragonsrc", editable=False
-    )
+    config_filename = models.CharField(max_length=30, default="dragonsrc")
     output_directory = models.CharField(
         max_length=255,
         blank=True,
     )
-    cal_manager_filename = models.CharField(
-        max_length=30, default="cal_manager.db", editable=False
-    )
+    cal_manager_filename = models.CharField(max_length=30, default="cal_manager.db")
     log_filename = models.CharField(max_length=30, default="log.log", editable=False)
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
@@ -115,6 +111,36 @@ class DRAGONSRun(models.Model):
             The full path to the output directory.
         """
         return self.get_raw_dir() / self.output_directory
+
+    def get_cal_manager_db_file(self) -> Path:
+        """Returns the full path to the calibration manager database file.
+
+        Returns
+        -------
+        `Path`
+            The full path to the calibration manager database file.
+        """
+        return self.get_output_dir() / self.cal_manager_filename
+
+    def get_log_file(self) -> Path:
+        """Returns the full path to the log file.
+
+        Returns
+        -------
+        `Path`
+            The full path to the log file.
+        """
+        return self.get_output_dir() / self.log_filename
+
+    def get_config_file(self) -> Path:
+        """Returns the full path to the configuration file.
+
+        Returns
+        -------
+        `Path`
+            The full path to the configuration file.
+        """
+        return self.get_output_dir() / self.config_filename
 
     def get_raw_dir(self) -> Path:
         """

--- a/src/goats_tom/static/js/dragons_setup_mvc.js
+++ b/src/goats_tom/static/js/dragons_setup_mvc.js
@@ -30,6 +30,7 @@ class SetupModel {
    */
   async formSubmit(observationRecordPk, formData) {
     const formDataObject = Object.fromEntries(formData);
+    console.log(formDataObject);
 
     try {
       const response = await this.api.post(

--- a/src/goats_tom/templates/dragons_index.html
+++ b/src/goats_tom/templates/dragons_index.html
@@ -38,7 +38,7 @@
             </div>
             <div class="col-12">
               <label for="configFilename" class="form-label">Configuration File</label>
-              <input type="text" class="form-control" id="configFilename" name="config_filename" readonly value="dragonsrc">
+              <input type="text" class="form-control" id="configFilename" name="config_filename" value="dragonsrc">
             </div>
             <div class="col-12">
               <label for="outputDirectory" class="form-label">Output Directory</label>
@@ -46,11 +46,7 @@
             </div>
             <div class="col-12">
               <label for="calManagerFilename" class="form-label">Calibration Manager File</label>
-              <input type="text" class="form-control" id="calManagerFilename" readonly name="cal_manager_filename" value="cal_manager.db">
-            </div>
-            <div class="col-12">
-              <label for="logFilename" class="form-label">Log File</label>
-              <input type="text" class="form-control" id="logFilename" name="log_filename" value="log.log" readonly>
+              <input type="text" class="form-control" id="calManagerFilename" name="cal_manager_filename" value="cal_manager.db">
             </div>
             <div class="col-12">
               <button type="submit" class="btn d-block w-100 btn-primary">Create Run</button>


### PR DESCRIPTION
- Remove ability to change log file name.
- Add helper functions to get path of DRAGONS setup files.
- Remove log setup from form.

[Jira Ticket: GOATS-250](https://noirlab.atlassian.net/browse/GOATS-250)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.