### PR TITLE
GOATS-178: Extend pagination to include item count.

### DIFF
--- a/doc/changes/GOATS-178.new.md
+++ b/doc/changes/GOATS-178.new.md
@@ -1,0 +1,1 @@
+Extended pagination to include item count: Overrode bootstrap_pagination to show "Showing x-y of n" message. Updated HTML template to display item counts.

--- a/environment.yml
+++ b/environment.yml
@@ -30,5 +30,5 @@ dependencies:
   # for tests, install with "pip install -e '.[test]'".
 
   # Uncomment the below lines to install from GitHub (requires repo access).
-  # - pip:pip in
+  # - pip:
   #   - git+https://github.com/gemini-hlsw/goats.git#branch=main

--- a/src/goats_tom/templates/pagination.html
+++ b/src/goats_tom/templates/pagination.html
@@ -1,0 +1,41 @@
+{% load bootstrap4 %}
+{% with bpurl=bootstrap_pagination_url|default:"" %}
+  <div class="d-flex align-items-baseline">
+    <ul class="{{ pagination_css_classes }}">
+        <li class="prev page-item{% if current_page == 1 %} disabled{% endif %}">
+            <a class="page-link" href="{% if current_page == 1 %}#{% else %}{% bootstrap_url_replace_param bpurl parameter_name 1 %}{% endif %}">
+                &laquo;
+            </a>
+        </li>
+
+        {% if pages_back %}
+            <li class="page-item">
+                <a class="page-link" href="{% bootstrap_url_replace_param bpurl parameter_name pages_back %}">&hellip;</a>
+            </li>
+        {% endif %}
+
+        {% for p in pages_shown %}
+            <li class="page-item{% if current_page == p %} active{% endif %}">
+                <a class="page-link" href="{% if current_page == p %}#{% else %}{% bootstrap_url_replace_param bpurl parameter_name p %}{% endif %}">
+                    {{ p }}
+                </a>
+            </li>
+        {% endfor %}
+
+        {% if pages_forward %}
+            <li class="page-item">
+                <a class="page-link" href="{% bootstrap_url_replace_param bpurl parameter_name pages_forward %}">&hellip;</a>
+            </li>
+        {% endif %}
+
+        <li class="last page-item{% if current_page == num_pages %} disabled{% endif %}">
+            <a class="page-link" href="{% if current_page == num_pages %}#{% else %}{% bootstrap_url_replace_param bpurl parameter_name num_pages %}{% endif %}">
+                &raquo;
+            </a>
+        </li>
+
+    </ul>
+    <span class="ms-2 small">Showing {{ start_index }}-{{ end_index }} of {{ total_count }}</span>
+
+  </div>
+{% endwith %}

--- a/src/goats_tom/templatetags/__init__.py
+++ b/src/goats_tom/templatetags/__init__.py
@@ -1,3 +1,4 @@
+from .bootstrap4_overrides import bootstrap_pagination
 from .custom_filters import starts_with
 from .gemini import render_goa_query_form, render_launch_dragons
 from .tom_overrides import goats_dataproduct_list_for_observation_saved
@@ -7,4 +8,5 @@ __all__ = [
     "render_goa_query_form",
     "render_launch_dragons",
     "goats_dataproduct_list_for_observation_saved",
+    "bootstrap_pagination",
 ]

--- a/src/goats_tom/templatetags/bootstrap4_overrides.py
+++ b/src/goats_tom/templatetags/bootstrap4_overrides.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from bootstrap4.templatetags.bootstrap4 import get_pagination_context, register
+from django.core.paginator import Page
+
+
+@register.inclusion_tag("pagination.html")
+def bootstrap_pagination(page: Page, **kwargs) -> dict[str, Any]:
+    """Render a Bootstrap pagination component with additional context. This function
+    extends the default pagination context to include the start index, end index, and
+    total count of items.
+
+    Parameters
+    ----------
+    page : `Page`
+        The page of results to show.
+
+    Returns
+    -------
+    `dict`
+        The context for rendering the pagination component, including
+        pagination details and item counts.
+    """
+    pagination_kwargs = kwargs.copy()
+    pagination_kwargs["page"] = page
+
+    # Get the default pagination context.
+    context = get_pagination_context(**pagination_kwargs)
+
+    # Add item counts to the context.
+    context["start_index"] = page.start_index()
+    context["end_index"] = page.end_index()
+    context["total_count"] = page.paginator.count
+
+    return context

--- a/tests/unit/goats_tom/templatetags/test_bootstrap4_overrides.py
+++ b/tests/unit/goats_tom/templatetags/test_bootstrap4_overrides.py
@@ -1,0 +1,59 @@
+import pytest
+from django.core.paginator import Paginator
+from goats_tom.templatetags import bootstrap_pagination
+
+
+@pytest.fixture
+def page():
+    # Create a mock Page object
+    paginator = Paginator(range(100), 10)  # 100 items, 10 per page
+    page = paginator.page(1)
+    return page
+
+
+def test_bootstrap_pagination_normal(page):
+    # Normal case
+    context = bootstrap_pagination(page)
+    assert context["start_index"] == 1
+    assert context["end_index"] == 10
+    assert context["total_count"] == 100
+
+
+def test_bootstrap_pagination_middle_page():
+    # Middle page case
+    paginator = Paginator(range(100), 10)
+    page = paginator.page(5)
+    context = bootstrap_pagination(page)
+    assert context["start_index"] == 41
+    assert context["end_index"] == 50
+    assert context["total_count"] == 100
+
+
+def test_bootstrap_pagination_last_page():
+    # Last page case
+    paginator = Paginator(range(95), 10)  # 95 items, 10 per page
+    page = paginator.page(10)
+    context = bootstrap_pagination(page)
+    assert context["start_index"] == 91
+    assert context["end_index"] == 95
+    assert context["total_count"] == 95
+
+
+def test_bootstrap_pagination_single_item():
+    # Single item case
+    paginator = Paginator(range(1), 1)  # 1 item, 1 per page
+    page = paginator.page(1)
+    context = bootstrap_pagination(page)
+    assert context["start_index"] == 1
+    assert context["end_index"] == 1
+    assert context["total_count"] == 1
+
+
+def test_bootstrap_pagination_no_items():
+    # No items case
+    paginator = Paginator([], 10)  # 0 items, 10 per page
+    page = paginator.page(1)
+    context = bootstrap_pagination(page)
+    assert context["start_index"] == 0
+    assert context["end_index"] == 0
+    assert context["total_count"] == 0


### PR DESCRIPTION
- Override bootstrap_pagination to show "Showing x-y of n" message.
- Update HTML template to display item counts.

[Jira Ticket: GOATS-178](https://noirlab.atlassian.net/browse/GOATS-178)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.