### PR TITLE
GOATS-286: Implement WebSocket support for DRAGONS logs.

### DIFF
--- a/doc/changes/GOATS-286.new.md
+++ b/doc/changes/GOATS-286.new.md
@@ -1,0 +1,1 @@
+Implemented WebSocket support for DRAGONS logs: Developed a Channels consumer to handle real-time log messages from DRAGONS. Added a new WebSocket endpoint for DRAGONS updates and integrated a WebSocket logging handler. Expanded testing to cover Django Channels consumers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ test = [
     "pytest-xdist",
     "pytest-cov",
     "pytest-django",
+    "pytest-asyncio",
     "factory_boy",
     "pytest-remotedata",
     "ruff"

--- a/src/goats_tom/consumers/__init__.py
+++ b/src/goats_tom/consumers/__init__.py
@@ -1,5 +1,11 @@
 from .download_state import DownloadState
+from .dragons_consumer import DRAGONSConsumer
 from .notification_instance import NotificationInstance
 from .updates_consumer import UpdatesConsumer
 
-__all__ = ["DownloadState", "NotificationInstance", "UpdatesConsumer"]
+__all__ = [
+    "DownloadState",
+    "NotificationInstance",
+    "UpdatesConsumer",
+    "DRAGONSConsumer",
+]

--- a/src/goats_tom/consumers/dragons_consumer.py
+++ b/src/goats_tom/consumers/dragons_consumer.py
@@ -1,0 +1,57 @@
+"""Class for DRAGONS updates through a websocket."""
+
+__all__ = ["DRAGONSConsumer"]
+import json
+
+from asgiref.sync import async_to_sync
+from channels.generic.websocket import WebsocketConsumer
+
+
+class DRAGONSConsumer(WebsocketConsumer):
+    """A WebSocket consumer that handles sending update to connected clients on the
+    DRAGONS page.
+
+    Attributes
+    ----------
+    group_name : `str`
+        The name of the group that this consumer handles updates for.
+    """
+
+    group_name = "dragons_group"
+
+    def connect(self) -> None:
+        """Adds this consumer to the DRAGONS group upon WebSocket connection."""
+        async_to_sync(self.channel_layer.group_add)(self.group_name, self.channel_name)
+        self.accept()
+
+    def disconnect(self, code: int) -> None:
+        """Removes this consumer from the DRAGONS group upon WebSocket disconnection.
+
+        Parameters
+        ----------
+        code : `int`
+            Return code to send on disconnect.
+        """
+        async_to_sync(self.channel_layer.group_discard)(
+            self.group_name, self.channel_name
+        )
+
+    def log_message(self, event: dict) -> None:
+        """Sends a log message to the client connected through WebSocket.
+
+        Parameters
+        ----------
+        event : `dict`
+            The event dictionary containing the log data.
+        """
+        # Construct the log message.
+        log = {
+            "update": "log",
+            "message": event["message"],
+            "run_id": event["run_id"],
+            "recipe_id": event["recipe_id"],
+            "reduce_id": event["reduce_id"],
+        }
+
+        # Send the log message to the WebSocket.
+        self.send(text_data=json.dumps(log))

--- a/src/goats_tom/consumers/updates_consumer.py
+++ b/src/goats_tom/consumers/updates_consumer.py
@@ -21,15 +21,12 @@ class UpdatesConsumer(WebsocketConsumer):
     group_name = "updates_group"
 
     def connect(self) -> None:
-        """Adds this consumer to the notification group upon
-        WebSocket connection.
-        """
+        """Adds this consumer to the updates group upon WebSocket connection."""
         async_to_sync(self.channel_layer.group_add)(self.group_name, self.channel_name)
         self.accept()
 
     def disconnect(self, code: int) -> None:
-        """Removes this consumer from the notification group
-        upon WebSocket disconnection.
+        """Removes this consumer from the updates group upon WebSocket disconnection.
 
         Parameters
         ----------
@@ -41,8 +38,7 @@ class UpdatesConsumer(WebsocketConsumer):
         )
 
     def notification_message(self, event: dict) -> None:
-        """Sends a notification message to the client connected through
-        WebSocket.
+        """Sends a notification message to the client connected through WebSocket.
 
         Parameters
         ----------
@@ -58,12 +54,11 @@ class UpdatesConsumer(WebsocketConsumer):
             "message": event["message"],
         }
 
-        # Send the notification message to the WebSocket
+        # Send the notification message to the WebSocket.
         self.send(text_data=json.dumps(notification))
 
     def download_message(self, event: dict) -> None:
-        """Sends a download update to the client connected through
-        WebSocket.
+        """Sends a download update to the client connected through WebSocket.
 
         Parameters
         ----------

--- a/src/goats_tom/logging/handlers/dragons.py
+++ b/src/goats_tom/logging/handlers/dragons.py
@@ -15,11 +15,12 @@ class DRAGONSHandler(logging.Handler):
     group_name = "dragons_group"
     func_type = "log.message"
 
-    def __init__(self, recipe_id: int, reduce_id: int) -> None:
+    def __init__(self, recipe_id: int, reduce_id: int, run_id: int) -> None:
         """Initialize the handler with the channel layer."""
         super().__init__()
         self.recipe_id = recipe_id
         self.reduce_id = reduce_id
+        self.run_id = run_id
         self.channel_layer = get_channel_layer()
 
     def emit(self, record: logging.LogRecord) -> None:
@@ -41,6 +42,7 @@ class DRAGONSHandler(logging.Handler):
                     "message": log_entry,
                     "recipe_id": self.recipe_id,
                     "reduce_id": self.reduce_id,
+                    "run_id": self.run_id,
                 },
             )
         except Exception:

--- a/src/goats_tom/routing.py
+++ b/src/goats_tom/routing.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .consumers import UpdatesConsumer
+from goats_tom.consumers import DRAGONSConsumer, UpdatesConsumer
 
 websocket_urlpatterns = [
     path("ws/updates/", UpdatesConsumer.as_asgi()),
+    path("ws/dragons/", DRAGONSConsumer.as_asgi()),
 ]

--- a/src/goats_tom/templates/dragons_index.html
+++ b/src/goats_tom/templates/dragons_index.html
@@ -94,6 +94,28 @@
 
 <script type="text/javascript">
   document.addEventListener("DOMContentLoaded", async () => {
+    // Connect to the websocket.
+    const dragonsWebSocket = new WebSocket("ws://localhost:8000/ws/dragons/");
+    
+    dragonsWebSocket.onopen = function(event) {
+      console.log('DRAGONS WebSocket connection established');
+    };
+
+    dragonsWebSocket.onmessage = function(event) {
+        const data = JSON.parse(event.data);
+
+        if (data.update === "log") {
+          console.log(data.message)
+        }
+    };
+
+    dragonsWebSocket.onclose = function(event) {
+        console.log('DRAGONS WebSocket connection closed', event);
+    };
+
+    dragonsWebSocket.onerror = function(error) {
+        console.log('DRAGONS WebSocket error', error);
+    };
     const api = new FetchWrapper("/api/");
     const recipesContainer = document.getElementById("recipesContainer");
     api.setCsrfToken("{{ csrf_token }}");

--- a/src/goats_tom/tests/settings.py
+++ b/src/goats_tom/tests/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     "goats_tom",
     "huey.contrib.djhuey",
     "fontawesomefree",
+    "daphne",
+    "channels",
     "corsheaders",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -81,6 +83,11 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = "goats_tom.tests.urls"
 
+CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+        },
+    }
 
 TEMPLATES = [
     {
@@ -101,7 +108,7 @@ TEMPLATES = [
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
 WSGI_APPLICATION = "goats_tom.wsgi.application"
-
+ASGI_APPLICATION = "goats_tom.asgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/tests/unit/goats_tom/consumers/test_dragons_consumer.py
+++ b/tests/unit/goats_tom/consumers/test_dragons_consumer.py
@@ -1,0 +1,52 @@
+"""Tests the `DRAGONSConsumer.`"""
+
+import pytest
+from channels.layers import get_channel_layer
+from channels.testing import WebsocketCommunicator
+from goats_tom.consumers import DRAGONSConsumer
+
+
+@pytest.mark.asyncio
+async def test_log_message_handling():
+    """Tests sending and receiving messages."""
+    communicator = WebsocketCommunicator(DRAGONSConsumer.as_asgi(), "/ws/dragons/")
+    connected, _ = await communicator.connect()
+    assert connected, "Connection to WebSocket failed"
+
+    # Send a message to the group which the consumer should receive and handle
+    channel_layer = get_channel_layer()
+    await channel_layer.group_send(
+        "dragons_group",
+        {
+            "type": "log.message",
+            "message": "Test log message",
+            "run_id": 1,
+            "recipe_id": 2,
+            "reduce_id": 3,
+        },
+    )
+
+    # Receive and validate the message from the consumer
+    response = await communicator.receive_json_from()
+    expected_response = {
+        "update": "log",
+        "message": "Test log message",
+        "run_id": 1,
+        "recipe_id": 2,
+        "reduce_id": 3,
+    }
+    assert response == expected_response, "Incorrect response received"
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_no_pending_messages():
+    """Tests for pending messages."""
+    communicator = WebsocketCommunicator(DRAGONSConsumer.as_asgi(), "/ws/dragons/")
+    await communicator.connect()
+
+    # No messages should be pending
+    assert await communicator.receive_nothing() is True, "Unexpected message pending"
+
+    await communicator.disconnect()

--- a/tests/unit/goats_tom/logging/handlers/test_dragons.py
+++ b/tests/unit/goats_tom/logging/handlers/test_dragons.py
@@ -20,7 +20,7 @@ class TestDRAGONSHandler(TestCase):
         self.mock_channel_layer.group_send = mock.AsyncMock()
 
         # Create an instance of the handler.
-        self.handler = DRAGONSHandler(recipe_id=123, reduce_id=456)
+        self.handler = DRAGONSHandler(recipe_id=123, reduce_id=456, run_id=789)
 
     def tearDown(self):
         self.patcher.stop()
@@ -52,6 +52,7 @@ class TestDRAGONSHandler(TestCase):
             "message": "Test log message",
             "recipe_id": 123,
             "reduce_id": 456,
+            "run_id": 789,
         }
         self.mock_channel_layer.group_send.assert_called_once_with(
             "dragons_group", expected_message


### PR DESCRIPTION
- Develop a Channels consumer to handle real-time log messages.
- Add a new WebSocket endpoint for DRAGONS updates.
- Integrate WebSocket logging handler for real-time display on console.
- Expand testing to include Django Channels consumers.

[Jira Ticket: GOATS-286](https://noirlab.atlassian.net/browse/GOATS-286)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.