### PR TITLE
GOATS-307: Add tests for additional Django Channels classes.

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,4 +1,4 @@
-name: Build release
+name: Build Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -63,4 +63,4 @@ jobs:
       - name: Run tests and calculate coverage
         run: |
           cd goats
-          pytest -r A -v -n auto --cov=goats --cov-report=term --cov=tests --cov-branch
+          pytest -r A -v -n auto --cov=src --cov-report=term --cov=tests --cov-branch

--- a/doc/changes/GOATS-307.new.md
+++ b/doc/changes/GOATS-307.new.md
@@ -1,0 +1,1 @@
+Wrote tests for additional Django Channels classes: Added unit tests for websocket classes responsible for the notification system.

--- a/src/goats_tom/consumers/notification_instance.py
+++ b/src/goats_tom/consumers/notification_instance.py
@@ -31,7 +31,23 @@ class NotificationInstance:
             "primary".
         """
         unique_id = f"{uuid.uuid4()}"
+        cls._send(unique_id, label, message, color)
 
+    @classmethod
+    def _send(cls, unique_id: str, label: str, message: str, color: str) -> None:
+        """Sends a notification.
+
+        Parameters
+        ----------
+        unique_id: `str`
+            The unique ID for the notification.
+        message : `str`
+            The body of the notification message to be sent.
+        label : `str`
+            The label of the notification.
+        color : `str`
+            The bootstrap color scheme to apply to the notification.
+        """
         channel_layer = get_channel_layer()
         async_to_sync(channel_layer.group_send)(
             cls.group_name,

--- a/tests/unit/goats_tom/consumers/test_download_state.py
+++ b/tests/unit/goats_tom/consumers/test_download_state.py
@@ -1,0 +1,99 @@
+"""Tests `DownloadState.`"""
+
+from unittest.mock import patch
+
+from goats_tom.consumers import DownloadState
+
+
+def test_format_bytes():
+    """Tests the format_bytes function thoroughly."""
+    assert DownloadState.format_bytes(500) == "500 B", "Incorrect format for bytes"
+    assert DownloadState.format_bytes(1024) == "1 KB", "Incorrect format for kilobytes"
+    assert DownloadState.format_bytes(1536) == "2 KB", "Incorrect format for kilobytes"
+    assert (
+        DownloadState.format_bytes(1048576) == "1.0 MB"
+    ), "Incorrect format for megabytes"
+    assert (
+        DownloadState.format_bytes(1572864) == "1.5 MB"
+    ), "Incorrect format for megabytes"
+    assert (
+        DownloadState.format_bytes(1073741824) == "1.00 GB"
+    ), "Incorrect format for gigabytes"
+    assert (
+        DownloadState.format_bytes(1099511627776) == "1.000 TB"
+    ), "Incorrect format for terabytes"
+    assert DownloadState.format_bytes(None) == "", "Incorrect format for None"
+
+
+def test_download_state_complete():
+    """Tests a complete download scenario with edge cases."""
+    with patch.object(DownloadState, "_send") as mock_send:
+        download_state = DownloadState()
+
+        # Send initial updates
+        download_state.update_and_send(
+            label="File Download",
+            status="Started",
+            downloaded_bytes=1024,
+            message="Download started",
+            done=False,
+            error=False,
+        )
+        # Verify that _send was called with the correct parameters.
+        mock_send.assert_called_with()
+        assert (
+            download_state.label == "File Download"
+        ), "Label not set correctly for initial update"
+        assert (
+            download_state.status == "Started"
+        ), "Status not set correctly for initial update"
+        assert (
+            download_state.downloaded_bytes == 1024
+        ), "Downloaded bytes not set correctly for initial update"
+        assert (
+            download_state.message == "Download started"
+        ), "Message not set correctly for initial update"
+        assert not download_state.done, "Done flag should be False for initial update"
+        assert not download_state.error, "Error flag should be False for initial update"
+
+        # Update the download state to in-progress.
+        download_state.update_and_send(
+            downloaded_bytes=2048, message="Download in progress", status="In Progress"
+        )
+
+        # Verify that _send was called again with the updated parameters.
+        mock_send.assert_called_with()
+        assert (
+            download_state.label == "File Download"
+        ), "Label should persist during update"
+        assert download_state.status == "In Progress", "Status not updated correctly"
+        assert (
+            download_state.downloaded_bytes == 2048
+        ), "Downloaded bytes not updated correctly"
+        assert (
+            download_state.message == "Download in progress"
+        ), "Message not updated correctly"
+        assert not download_state.done, "Done flag should be False during update"
+        assert not download_state.error, "Error flag should be False during update"
+
+        # Complete the download.
+        download_state.update_and_send(
+            downloaded_bytes=4096, message="Download complete", done=True
+        )
+
+        # Verify that _send was called again with the completion parameters.
+        mock_send.assert_called_with()
+        assert (
+            download_state.label == "File Download"
+        ), "Label should persist during completion"
+        assert (
+            download_state.status == "In Progress"
+        ), "Status should persist during completion"
+        assert (
+            download_state.downloaded_bytes == 4096
+        ), "Downloaded bytes not updated correctly during completion"
+        assert (
+            download_state.message == "Download complete"
+        ), "Message not updated correctly during completion"
+        assert download_state.done, "Done flag should be True during completion"
+        assert not download_state.error, "Error flag should be False during completion"

--- a/tests/unit/goats_tom/consumers/test_notification_instance.py
+++ b/tests/unit/goats_tom/consumers/test_notification_instance.py
@@ -1,0 +1,24 @@
+"""Tests for `NotificationInstance`."""
+
+from unittest.mock import patch
+
+from goats_tom.consumers import NotificationInstance
+
+
+def test_notification_instance():
+    """Tests creating and sending a notification."""
+    with patch.object(NotificationInstance, "_send") as mock_send:
+        # Create and send a notification
+        NotificationInstance.create_and_send(
+            label="Alert", message="Test notification", color="warning"
+        )
+
+        # Verify that _send was called with the correct parameters.
+        mock_send.assert_called_once()
+        args, _ = mock_send.call_args
+        unique_id, label, message, color = args
+
+        assert label == "Alert", "Label not set correctly"
+        assert message == "Test notification", "Message not set correctly"
+        assert color == "warning", "Color not set correctly"
+        assert isinstance(unique_id, str), "Unique ID not set correctly"

--- a/tests/unit/goats_tom/consumers/test_updates_consumer.py
+++ b/tests/unit/goats_tom/consumers/test_updates_consumer.py
@@ -1,0 +1,93 @@
+"""Tests for `UpdatesConsumer.`"""
+
+import pytest
+from channels.layers import get_channel_layer
+from channels.testing import WebsocketCommunicator
+from goats_tom.consumers import UpdatesConsumer
+
+
+@pytest.mark.asyncio
+async def test_notification_message_handling():
+    """Tests sending and receiving notification messages."""
+    communicator = WebsocketCommunicator(UpdatesConsumer.as_asgi(), "/ws/updates/")
+    connected, _ = await communicator.connect()
+    assert connected, "Connection to WebSocket failed"
+
+    # Send a notification message to the group which the consumer should receive and
+    # handle.
+    channel_layer = get_channel_layer()
+    await channel_layer.group_send(
+        "updates_group",
+        {
+            "type": "notification.message",
+            "unique_id": "1234",
+            "color": "red",
+            "label": "Alert",
+            "message": "Test notification message",
+        },
+    )
+
+    # Receive and validate the message from the consumer.
+    response = await communicator.receive_json_from()
+    expected_response = {
+        "update": "notification",
+        "unique_id": "1234",
+        "color": "red",
+        "label": "Alert",
+        "message": "Test notification message",
+    }
+    assert response == expected_response, "Incorrect response received"
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_download_message_handling():
+    """Tests sending and receiving download messages."""
+    communicator = WebsocketCommunicator(UpdatesConsumer.as_asgi(), "/ws/updates/")
+    connected, _ = await communicator.connect()
+    assert connected, "Connection to WebSocket failed"
+
+    # Send a download message to the group which the consumer should receive and handle.
+    channel_layer = get_channel_layer()
+    await channel_layer.group_send(
+        "updates_group",
+        {
+            "type": "download.message",
+            "unique_id": "5678",
+            "label": "Download Task",
+            "message": "Download in progress",
+            "status": "In Progress",
+            "downloaded_bytes": "2 KB",
+            "done": False,
+            "error": False,
+        },
+    )
+
+    # Receive and validate the message from the consumer.
+    response = await communicator.receive_json_from()
+    expected_response = {
+        "update": "download",
+        "unique_id": "5678",
+        "label": "Download Task",
+        "message": "Download in progress",
+        "status": "In Progress",
+        "downloaded_bytes": "2 KB",
+        "done": False,
+        "error": False,
+    }
+    assert response == expected_response, "Incorrect response received"
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_no_pending_messages():
+    """Tests for no pending messages."""
+    communicator = WebsocketCommunicator(UpdatesConsumer.as_asgi(), "/ws/updates/")
+    await communicator.connect()
+
+    # No messages should be pending.
+    assert await communicator.receive_nothing() is True, "Unexpected message pending"
+
+    await communicator.disconnect()


### PR DESCRIPTION
- Add unit tests for websocket classes responsible for the notification system.

[Jira Ticket: GOATS-307](https://noirlab.atlassian.net/browse/GOATS-307)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.