### PR TITLE
GOATS-335: Disable retries for dramatiq background tasks.

### DIFF
--- a/doc/changes/GOATS-335.bugfix.md
+++ b/doc/changes/GOATS-335.bugfix.md
@@ -1,0 +1,1 @@
+Disabled automatic retries for failed DRAGONS reductions and GOA downloads.

--- a/src/goats_tom/tasks/tasks.py
+++ b/src/goats_tom/tasks/tasks.py
@@ -32,7 +32,7 @@ matplotlib.use("Agg", force=True)
 logger = logging.getLogger(__name__)
 
 
-@dramatiq.actor
+@dramatiq.actor(max_retries=0)
 def run_dragons_reduce(reduce_id: int) -> None:
     """Executes a reduction process in the background.
 
@@ -139,7 +139,8 @@ def run_dragons_reduce(reduce_id: int) -> None:
         )
         raise
 
-@dramatiq.actor
+
+@dramatiq.actor(max_retries=0)
 def download_goa_files(
     serialized_observation_record: str, query_params: dict, user: int
 ) -> None:


### PR DESCRIPTION
[Jira Ticket: GOATS-335](https://noirlab.atlassian.net/browse/GOATS-335)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.