### PR TITLE
GOATS-345: Enable custom recipe input for DRAGONS.

### DIFF
--- a/doc/changes/GOATS-345.new.md
+++ b/doc/changes/GOATS-345.new.md
@@ -1,0 +1,1 @@
+Enabled custom recipe input for DRAGONS: Users can now specify and utilize their own recipes in the DRAGONS reduction process.


### PR DESCRIPTION
- Implement dynamic module creation to allow user-defined recipes.
- Extend sys.modules dynamically to include user-generated functions.
- Ensure each task has a unique namespace by using UUIDs for module names.
- Add cleanup logic to remove temporary modules post-execution to prevent namespace pollution.

[Jira Ticket: GOATS-345](https://noirlab.atlassian.net/browse/GOATS-345)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.