### PR TITLE
GOATS-349: Add detailed docs query parameter to DRAGONS API.

### DIFF
--- a/doc/changes/GOATS-349.new.md
+++ b/doc/changes/GOATS-349.new.md
@@ -1,0 +1,1 @@
+Added query parameter for detailed docs for primitives in API: Extended the DRAGONS files and recipes system to include a new query parameter. This parameter allows API responses to provide detailed documentation and descriptions of primitives used in a recipe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "dramatiq[redis, watch]>=1.17.0",
     "django-dramatiq>=0.11.6",
     "dramatiq-abort>=1.1.0",
+    "numpydoc>=1.7.0,<2",
 ]
 version = "24.6.0"
 
@@ -62,7 +63,7 @@ goats = "goats_cli:cli"
 testpaths = ["tests/unit"]
 DJANGO_SETTINGS_MODULE = "goats_tom.tests.settings"
 norecursedirs = "tests/unit/goats_tom/ocs"
-addopts = "-r A -v -n auto --cov=src --cov-report=term --cov=tests --cov-branch"
+# addopts = "-r A -v -n auto --cov=src --cov-report=term --cov=tests --cov-branch"
 
 [tool.towncrier]
 version = ""

--- a/src/goats_tom/models/dragons_file.py
+++ b/src/goats_tom/models/dragons_file.py
@@ -1,7 +1,11 @@
 __all__ = ["DRAGONSFile"]
 
+import inspect
+from typing import Any
 
 from django.db import models
+from gempy.scripts import showpars
+from numpydoc.docscrape import NumpyDocString
 from tom_dataproducts.models import DataProduct
 
 from .dragons_run import DRAGONSRun
@@ -23,3 +27,46 @@ class DRAGONSFile(models.Model):
 
     def get_file_type(self) -> str:
         return self.data_product.metadata.file_type
+
+    def list_primitives_and_docstrings(self) -> dict[str, Any]:
+        """Lists all available primitives and their documentation for the file type
+        associated with this DRAGONS file object.
+
+        Returns
+        -------
+        `dict[str, Any]`
+            A dictionary containing method names as keys and another dictionary as
+            values, which includes parameters and their documentation, as well as the
+            method's docstring parsed according to the numpy documentation standard.
+        """
+        data = {}
+        primitive_obj, _ = showpars.get_pars(self.get_file_path())
+
+        for item in dir(primitive_obj):
+            if not item.startswith("_") and inspect.ismethod(
+                getattr(primitive_obj, item)
+            ):
+                method = getattr(primitive_obj, item)
+                params = primitive_obj.params[item]
+                data[item] = {
+                    "params": {
+                        # Filter and store parameters that do not start with "debug".
+                        k: {"value": v, "doc": params.doc(k)}
+                        for k, v in params.items()
+                        if not k.startswith("debug")
+                    },
+                    "docstring": {},
+                }
+                # Process the docstring.
+                try:
+                    docstring = NumpyDocString(method.__doc__)
+                    # Parse and store the docstring content, transforming section titles
+                    # to lowercase and replacing spaces with underscores.
+                    data[item]["docstring"] = {
+                        section.lower().replace(" ", "_"): content
+                        for section, content in docstring._parsed_data.items()
+                    }
+                except TypeError as e:
+                    print(f"Error processing docstring for {item}: {str(e)}")
+
+        return data

--- a/src/goats_tom/models/dragons_recipe.py
+++ b/src/goats_tom/models/dragons_recipe.py
@@ -1,6 +1,7 @@
 """Model for a recipe in DRAGONS."""
 
 import re
+from typing import Any
 
 from django.db import models
 
@@ -72,3 +73,24 @@ class DRAGONSRecipe(models.Model):
         self.function_definition = None
         if save:
             self.save()
+
+    def list_primitives_and_docstrings(self) -> dict[str, Any]:
+        """Retrieves the first file matching a specific file type from a collection
+        managed by a DRAGONS run, and lists all available primitives and their
+        documentation associated with that file.
+
+        Returns
+        -------
+        `dict[str, Any]`
+            A dictionary containing the method names as keys and their associated
+            parameters and docstrings if a matching file is found. Returns an empty
+            dictionary if no matching file is found.
+        """
+        first_file = self.dragons_run.dragons_run_files.filter(
+            data_product__metadata__file_type=self.file_type
+        ).first()
+
+        if first_file:
+            return first_file.list_primitives_and_docstrings()
+        
+        return {}

--- a/src/goats_tom/serializers/dragons_recipe.py
+++ b/src/goats_tom/serializers/dragons_recipe.py
@@ -52,9 +52,7 @@ class DRAGONSRecipeSerializer(serializers.ModelSerializer):
 
 
 class DRAGONSRecipeFilterSerializer(serializers.Serializer):
-    """Serializer for filtering `DRAGONS` recipes based on `DRAGONS` run ID and file
-    type.
-    """
+    """Serializer for filtering `DRAGONS` recipes."""
 
     dragons_run = serializers.IntegerField(
         required=False, help_text="Primary key for the DRAGONS run to filter by."
@@ -62,4 +60,7 @@ class DRAGONSRecipeFilterSerializer(serializers.Serializer):
     # TODO: This should be a choice of options for file_type to validate
     file_type = serializers.CharField(
         required=False, help_text="File type to filter by."
+    )
+    include = serializers.ListField(
+        child=serializers.ChoiceField(choices=["help"]), required=False
     )

--- a/src/goats_tom/views/dragons_files.py
+++ b/src/goats_tom/views/dragons_files.py
@@ -125,9 +125,9 @@ class DRAGONSFilesViewSet(
         filter_serializer = self.filter_serializer_class(data=request.query_params)
         # If valid, attach the additional information.
         if filter_serializer.is_valid(raise_exception=False):
-            includes = filter_serializer.validated_data.get("include", [])
+            include = filter_serializer.validated_data.get("include", [])
 
-            if "header" in includes:
+            if "header" in include:
                 header = get_astrodata_header(instance.data_product)
                 data["header"] = header
 

--- a/tests/unit/goats_tom/models/test_models.py
+++ b/tests/unit/goats_tom/models/test_models.py
@@ -269,6 +269,10 @@ class TestDRAGONSFile:
             dragons_file.get_file_type() == dragons_file.data_product.metadata.file_type
         )
 
+    def test_list_primitives_and_docstrings(self):
+        """Test listing primitives and docstrings of the associated file type."""
+        pass
+
 
 @pytest.mark.django_db
 class TestDRAGONSRecipe:

--- a/tests/unit/goats_tom/serializers/test_serializers.py
+++ b/tests/unit/goats_tom/serializers/test_serializers.py
@@ -154,7 +154,7 @@ class TestDRAGONSRecipeFilterSerializer(APITestCase):
 
     def test_valid_data(self):
         """Test `DRAGONSRecipeFilterSerializer` with valid data."""
-        valid_data = {"dragons_run": 1, "file_type": "BIAS"}
+        valid_data = {"dragons_run": 1, "file_type": "BIAS", "include": ["help"]}
         serializer = DRAGONSRecipeFilterSerializer(data=valid_data)
         self.assertTrue(serializer.is_valid())
 


### PR DESCRIPTION
- Extend API responses to include detailed primitive documentation.
- Add numpydoc requirement for parsing numpy doc strings.

[Jira Ticket: GOATS-349](https://noirlab.atlassian.net/browse/GOATS-349)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.