### PR TITLE
GOATS-350: Connect frontend and backend for help documentation.

### DIFF
--- a/doc/changes/GOATS-350.new.md
+++ b/doc/changes/GOATS-350.new.md
@@ -1,0 +1,1 @@
+Connected frontend and backend for help docs: Established linkage between the frontend and backend systems for fetching and displaying help documentation related to primitives. Designed the user interface to comprehensively present all components of numpy doc strings and parameters when available.

--- a/src/goats_tom/models/dragons_file.py
+++ b/src/goats_tom/models/dragons_file.py
@@ -66,7 +66,8 @@ class DRAGONSFile(models.Model):
                         section.lower().replace(" ", "_"): content
                         for section, content in docstring._parsed_data.items()
                     }
-                except TypeError as e:
-                    print(f"Error processing docstring for {item}: {str(e)}")
+                except (ValueError, TypeError):
+                    # print(f"Error processing docstring for {item}: {str(e)}")
+                    pass
 
         return data

--- a/src/goats_tom/static/js/recipe_mvc.js
+++ b/src/goats_tom/static/js/recipe_mvc.js
@@ -45,6 +45,8 @@ class RecipeModel {
    * Fetches a specific recipe by its ID.
    * @param {number} recipeId The ID of the recipe to fetch.
    * @returns {Promise<Object>} A promise that resolves to the recipe object.
+   * @throws {Error} If the API request fails, an error is logged to the console.
+   * @async
    */
   async fetchRecipe(recipeId) {
     try {
@@ -60,6 +62,7 @@ class RecipeModel {
    * Starts the reduction process for a given recipe.
    * @param {number} recipe The ID of the recipe to be reduced.
    * @returns {Promise<Object>} A promise that resolves to the response from the server.
+   * @throws {Error} If the API request fails, an error is logged to the console.
    * @async
    */
   async startReduce(recipe) {
@@ -77,6 +80,7 @@ class RecipeModel {
    * Stops the reduction process.
    * @param {number} reduce The ID of the reduction to be stopped.
    * @returns {Promise<Object>} A promise that resolves to the response from the server.
+   * @throws {Error} If the API request fails, an error is logged to the console.
    * @async
    */
   async stopReduce(reduce) {
@@ -90,9 +94,24 @@ class RecipeModel {
     }
   }
 
+  /**
+   * Asynchronously fetches help documentation for a specified recipe.
+   * @param {string} recipeId The ID of the recipe for which help documentation is being requested.
+   * @returns {Promise<Object>} A promise that resolves with the help documentation for the
+   * specified recipe.
+   * @throws {Error} If the API request fails, an error is logged to the console.
+   * @async
+   */
   async fetchHelp(recipeId) {
-    // TODO: Finish fetching from API.
-    return;
+    try {
+      const response = await this.api.get(
+        `${this.recipesUrl}${recipeId}/?include=help`
+      );
+      this.recipe = response;
+      return response;
+    } catch (error) {
+      console.error("Error stopping recipe:", error);
+    }
   }
 
   /**
@@ -717,15 +736,11 @@ class RecipeController {
   handleShowHelp = async (recipeId) => {
     // Clear and show loading bar since it is not hidden.
     window.helpOffcanvas.clearTitleAndContent();
-    window.helpOffcanvas.showLoading();
+    window.helpOffcanvas.isLoading();
 
     // Pass in the recipe to get the help for it.
     const recipe = await this.model.fetchHelp(recipeId);
-
-    // Update the help offcanvas and show the content.
-    window.helpOffcanvas.setTitle("Some Title");
-    window.helpOffcanvas.setContent("Test Data");
-    window.helpOffcanvas.showContent();
+    window.helpOffcanvas.updateAndShowPrimitivesDocumentation(recipe);
   };
 
   /**


### PR DESCRIPTION
- Establish data linkage for fetching and displaying primitive help docs.
- Design UI to display all parts of numpy doc strings and parameters.
- Add exception handling for numpydoc parsing errors in DRAGONS doc strings.

[Jira Ticket: GOATS-350](https://noirlab.atlassian.net/browse/GOATS-350)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.