### PR TITLE
GOATS-400: Extend background worker timeout to 24 hours.

### DIFF
--- a/doc/changes/GOATS-400.new.md
+++ b/doc/changes/GOATS-400.new.md
@@ -1,0 +1,1 @@
+Extended background worker timeout and made configurable: Allowed users to configure the time limit for background tasks via Django settings, enabling better control over task execution duration.

--- a/src/goats_setup/templates/goats_setup/settings.tmpl
+++ b/src/goats_setup/templates/goats_setup/settings.tmpl
@@ -142,7 +142,7 @@ DRAMATIQ_BROKER = {
         "dramatiq.middleware.Callbacks",
     ]
 }
-
+DRAMATIQ_ACTOR_TIME_LIMIT = 86400000  # In milliseconds
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
- Allow users to set the time limit for background tasks in Django settings.

[Jira Ticket: GOATS-400](https://noirlab.atlassian.net/browse/GOATS-400)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.