### PR TITLE
GOATS-405: Add truncation for grouping values.

### DIFF
--- a/doc/changes/GOATS-405.new.md
+++ b/doc/changes/GOATS-405.new.md
@@ -1,0 +1,1 @@
+Added truncation for grouped values: Grouping values are now truncated to include file counts.

--- a/src/goats_tom/astroquery/gemini.py
+++ b/src/goats_tom/astroquery/gemini.py
@@ -450,7 +450,6 @@ class ObservationsClass(QueryWithLogin):
 
         """
         url = self.url_helper.get_summary_url(*args, **kwargs)
-        print("URL: ", url)
 
         response = self._request(
             method="GET",
@@ -717,7 +716,6 @@ class ObservationsClass(QueryWithLogin):
         # Convert destination folder.
         dest_folder = Path(dest_folder).expanduser()
         url = self.url_helper.get_tar_file_url(*query_args, **query_kwargs)
-        print(url)
 
         response = self._session.get(url, stream=True)
         response.raise_for_status()

--- a/src/goats_tom/static/js/dragons_setup_mvc.js
+++ b/src/goats_tom/static/js/dragons_setup_mvc.js
@@ -1015,7 +1015,7 @@ class SetupView {
     groups.forEach((group, index) => {
       // Determine the correct label for the option.
       const option = new Option(
-        `${group.groupName} ${Utils.getFileCountLabel(group.count)}`,
+        `${Utils.truncateText(group.groupName)} ${Utils.getFileCountLabel(group.count)}`,
         group.groupName
       );
       select.add(option);

--- a/src/goats_tom/static/js/utils.js
+++ b/src/goats_tom/static/js/utils.js
@@ -147,4 +147,25 @@ class Utils {
   static getFileCountLabel(count) {
     return count === 1 ? "(1 file)" : `(${count} files)`;
   }
+
+  /**
+   * Truncates text to a specified length and appends an ellipsis ('...') if the text is longer
+   * than the maximum length.
+   * @param {string} text - The text to be truncated.
+   * @param {number} [maxLength=25] - The maximum length of the text after truncation.
+   * @returns {string} The truncated text with an ellipsis if it was cut off.
+   */
+  static truncateText(text, maxLength = 25) {
+    // Split the text by the pipe character and process each part.
+    return text
+      .split("|")
+      .map((part) => {
+        if (part.length > maxLength) {
+          // Subtract 4 from maxLength to accommodate the ellipsis and space.
+          return part.substring(0, maxLength - 4) + "... ";
+        }
+        return part;
+      })
+      .join("|"); // Join the processed parts back with the pipe character.
+  }
 }


### PR DESCRIPTION
- Implement utility function to truncate text.

[Jira Ticket: GOATS-405](https://noirlab.atlassian.net/browse/GOATS-405)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.