### PR TITLE
GOATS-421: Added file upload support for calibration database.

### DIFF
--- a/doc/changes/GOATS-421.new.md
+++ b/doc/changes/GOATS-421.new.md
@@ -1,0 +1,1 @@
+Added file upload support: Enabled uploading files to the calibration database for DRAGONS reduction.

--- a/src/goats_tom/static/js/dragons_caldb_mvc.js
+++ b/src/goats_tom/static/js/dragons_caldb_mvc.js
@@ -194,7 +194,7 @@ class CaldbTemplate {
 
       const removeButton = Utils.createElement("a", ["link-danger"]);
       removeButton.setAttribute("type", "button");
-      removeButton.setAttribute("data-file", item.name);
+      removeButton.setAttribute("data-filename", item.name);
       removeButton.setAttribute("data-action", "remove");
       // Create icon element for button.
       const icon = Utils.createElement("i", ["fa-solid", "fa-circle-minus"]);
@@ -283,7 +283,7 @@ class CaldbView {
         break;
       case "remove":
         Utils.delegate(this.table, selector, "click", (e) =>
-          handler({ filename: e.target.dataset.file })
+          handler({ filename: e.target.dataset.filename })
         );
         break;
       case "refresh":
@@ -337,7 +337,7 @@ class CaldbModel {
   async removeFile(filename) {
     try {
       const body = {
-        file: filename,
+        filename: filename,
         action: "remove",
       };
       const response = await this.api.patch(`${this.caldbUrl}${this.runId}/`, body);
@@ -348,18 +348,25 @@ class CaldbModel {
     }
   }
 
-  // TODO:
+  /**
+   * Adds a file to the calibration database.
+   * @async
+   * @param {File} file - The file object to upload.
+   * @returns {Promise<void>} - A promise that resolves when the file has been added successfully.
+   */
   async addFile(file) {
-    // await this._addOrRemoveFile(file, "add");
-    console.log(`Called 'model.addFile' ${file.name}`);
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("action", "add");
 
-    return;
     try {
-      const body = {
-        file: file,
-        action: "add",
-      };
-      const response = await this.api.patch(`${this.caldbUrl}${this.runId}/`, body);
+      const body = formData;
+      const response = await this.api.patch(
+        `${this.caldbUrl}${this.runId}/`,
+        body,
+        {},
+        false
+      );
       this.setData(response);
     } catch (error) {
       console.error(`Error adding file:`, error);
@@ -432,7 +439,6 @@ class CaldbController {
    * @param {string} filename - The filename of the item to remove.
    */
   async remove(filename) {
-    console.log("Called 'remove': ", filename);
     await this.model.removeFile(filename);
     this.view.render("update", { data: this.model.getData() });
   }
@@ -443,7 +449,6 @@ class CaldbController {
    * @param {File} file - A file object to add to the database.
    */
   async add(file) {
-    console.log(`Called 'controller.add' ${file.name}`);
     await this.model.addFile(file);
     this.view.render("update", { data: this.model.getData() });
   }

--- a/src/goats_tom/static/js/fetch_wrapper.js
+++ b/src/goats_tom/static/js/fetch_wrapper.js
@@ -33,6 +33,11 @@ class FetchWrapper {
     // Merge provided headers with defaults.
     options.headers = { ...this.defaultHeaders, ...options.headers };
 
+    // If the body is FormData, remove the 'Content-Type' header to let the browser set it.
+    if (options.body instanceof FormData) {
+      delete options.headers["Content-Type"];
+    }
+
     try {
       const response = await fetch(url, { ...options, credentials: "same-origin" });
 
@@ -64,13 +69,14 @@ class FetchWrapper {
    * @param {string} endpoint - The endpoint for the POST request.
    * @param {Object} body - The body data to send with the POST request.
    * @param {Object} [options={}] - Additional options for the POST request.
+   * @param {boolean} [stringify=true] - Whether to stringify the body.
    * @returns {Promise<Object>} - A promise resolving to the response data.
    */
-  post(endpoint, body, options = {}) {
+  post(endpoint, body, options = {}, stringify = true) {
     return this.request(endpoint, {
       ...options,
       method: "POST",
-      body: JSON.stringify(body),
+      body: stringify ? JSON.stringify(body) : body,
     });
   }
 
@@ -79,13 +85,14 @@ class FetchWrapper {
    * @param {string} endpoint - The endpoint for the PUT request.
    * @param {Object} body - The body data to send with the PUT request.
    * @param {Object} [options={}] - Additional options for the PUT request.
+   * @param {boolean} [stringify=true] - Whether to stringify the body.
    * @returns {Promise<Object>} - A promise resolving to the response data.
    */
-  put(endpoint, body, options = {}) {
+  put(endpoint, body, options = {}, stringify = true) {
     return this.request(endpoint, {
       ...options,
       method: "PUT",
-      body: JSON.stringify(body),
+      body: stringify ? JSON.stringify(body) : body,
     });
   }
 
@@ -104,13 +111,14 @@ class FetchWrapper {
    * @param {string} endpoint - The endpoint for the PATCH request.
    * @param {Object} body - The body data to send with the PATCH request.
    * @param {Object} [options={}] - Additional options for the PATCH request.
+   * @param {boolean} [stringify=true] - Whether to stringify the body.
    * @returns {Promise<Object>} - A promise resolving to the response data.
    */
-  patch(endpoint, body, options = {}) {
+  patch(endpoint, body, options = {}, stringify = true) {
     return this.request(endpoint, {
       ...options,
       method: "PATCH",
-      body: JSON.stringify(body),
+      body: stringify ? JSON.stringify(body) : body,
     });
   }
 }


### PR DESCRIPTION
- Modified the fetch wrapper to handle file objects.
- Extended the caldb serializer to accept file objects and actions.
- Modified the view to save uploaded files in a specific calibrations directory.

[Jira Ticket: GOATS-421](https://noirlab.atlassian.net/browse/GOATS-421)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.