### PR TITLE
GOATS-464: Remove hardcoded observation ID.

### DIFF
--- a/doc/changes/GOATS-464.bugfix.md
+++ b/doc/changes/GOATS-464.bugfix.md
@@ -1,0 +1,1 @@
+Fixed observation record ID handling: Corrected an issue where a hardcoded observation ID from testing persisted into production, ensuring that only runs associated with an actual observation record are displayed.

--- a/doc/changes/GOATS-465.bugfix.md
+++ b/doc/changes/GOATS-465.bugfix.md
@@ -1,0 +1,1 @@
+Fixed filter expression and ID uniqueness bugs: Resolved an issue where user-provided filter expressions were not correctly used in filtering and grouping available files. Additionally, improved the uniqueness of file checkbox IDs by incorporating more identifying information, addressing an issue uncovered when allowing user access to all files.

--- a/src/goats_tom/templates/dragons_index.html
+++ b/src/goats_tom/templates/dragons_index.html
@@ -73,7 +73,7 @@
       );
       window.api = new API("/api/", "{{ csrf_token }}");
       window.modal = new Modal(document.getElementById("modalContainer"));
-      this.runSetup = new RunSetup(1, document.getElementById("runSetupContainer"));
+      this.runSetup = new RunSetup("{{observation_record.id}}", document.getElementById("runSetupContainer"));
       this.runSetup.init();
 
       this.initialized = false;


### PR DESCRIPTION
- Remove hardcoded observation ID left from testing.
- Ensure display of runs is tied to actual observation records.

[Jira Ticket: GOATS-464](https://noirlab.atlassian.net/browse/GOATS-464)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.