### PR TITLE
GOATS-479: Sort files by observation type to match DRAGONS expectations.

### DIFF
--- a/doc/changes/GOATS-479.change.md
+++ b/doc/changes/GOATS-479.change.md
@@ -1,0 +1,1 @@
+Sort files by observation type for DRAGONS compatibility: Ensured the first file in the list matches the recipe's observation type to prevent mismatches with tags and primitives.


### PR DESCRIPTION
- Place the file with the matching observation type first in the file list.

[Jira Ticket: GOATS-479](https://noirlab.atlassian.net/browse/GOATS-479)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.