### PR TITLE
GOATS-489: Implement dataproduct visualizer template tag.

### DIFF
--- a/src/goats_tom/templates/partials/dataproduct_visualizer.html
+++ b/src/goats_tom/templates/partials/dataproduct_visualizer.html
@@ -1,0 +1,37 @@
+<div class="container mt-3">
+  <div class="row g-3">
+    <div class="col-12">
+      <div id="{{ data_type }}Plot" class="plotly-container"></div>
+    </div>
+    <div class="col-12">
+      <div style="overflow-y: auto; height: 400px">
+        <table class="table">
+          <thead>
+            <tr>
+              <th></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="{{ data_type }}PlotTBody">
+            {% for dataproduct in dataproducts %}
+            <tr
+              data-file="{{ dataproduct.data.name}}"
+              data-dataproduct-id="{{ dataproduct.id }}"
+              data-data-type="{{ data_type }}">
+              <td>{{ dataproduct.data.name }}</td>
+              <td>
+                <button
+                  type="button"
+                  class="btn btn-primary btn-sm plot-button"
+                  data-action="plot">
+                  Plot
+                </button>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/goats_tom/templates/tom_targets/target_detail.html
+++ b/src/goats_tom/templates/tom_targets/target_detail.html
@@ -1,5 +1,5 @@
 {% extends 'tom_common/target-dash.html' %}
-{% load comments bootstrap4 tom_common_extras targets_extras observation_extras dataproduct_extras static cache gemini tom_overrides %}
+{% load comments bootstrap4 tom_common_extras targets_extras observation_extras dataproduct_extras static cache gemini tom_overrides dataproduct_visualizer %}
 {% block title %}Target {{ object.name }}{% endblock %}
 <!-- {% block additional_css %}
 <link rel="stylesheet" href="{% static 'tom_common/css/main.css' %}">
@@ -88,7 +88,7 @@
     {% get_photometry_data object %}
     </div>
   <div class="tab-pane" id="spectroscopy">
-    {% spectroscopy_for_target target %}
+    {% dataproduct_visualizer target "spectroscopy" %}
   </div>
 </div>
 {% endblock %}

--- a/src/goats_tom/templatetags/__init__.py
+++ b/src/goats_tom/templatetags/__init__.py
@@ -1,5 +1,6 @@
 from .bootstrap4_overrides import bootstrap_pagination
 from .custom_filters import starts_with
+from .dataproduct_visualizer import dataproduct_visualizer
 from .gemini import render_goa_query_form, render_launch_dragons
 from .target_navbar import render_target_navbar
 from .tom_overrides import goats_dataproduct_list_for_observation_saved
@@ -10,5 +11,6 @@ __all__ = [
     "render_launch_dragons",
     "goats_dataproduct_list_for_observation_saved",
     "bootstrap_pagination",
-    "render_target_navbar"
+    "render_target_navbar",
+    "dataproduct_visualizer",
 ]

--- a/src/goats_tom/templatetags/dataproduct_visualizer.py
+++ b/src/goats_tom/templatetags/dataproduct_visualizer.py
@@ -1,0 +1,43 @@
+"""Module for providing the dataproudcts to visualize."""
+
+__all__ = ["dataproduct_visualizer"]
+
+from typing import Any
+
+from django import template
+from django.db.models import Q
+from django.template.context import RequestContext
+from tom_dataproducts.models import DataProduct
+from tom_targets.models import BaseTarget
+
+register = template.Library()
+
+
+@register.inclusion_tag("partials/dataproduct_visualizer.html", takes_context=True)
+def dataproduct_visualizer(
+    context: RequestContext, target: BaseTarget, data_type: str = "spectroscopy"
+) -> dict[str, Any]:
+    """Returns the dataproducts available to plot for a specific data type.
+
+    Parameters
+    ----------
+    context : `RequestContext`
+        The template context, including the user and request information.
+    target : `BaseTarget`
+        The target object for which to retrieve data products.
+    data_type : `str`, optional
+        The type of data product to filter by, by default "spectroscopy".
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary containing the target, the filtered data products, and the data
+        type.
+    """
+    # Get all the dataproducts.
+    # FIXME: Add in permission check to only get appropriate dataproducts
+    dataproducts = DataProduct.objects.filter(target=target).filter(
+        Q(data_product_type=data_type) | Q(data_product_type="fits_file")
+    )
+
+    return {"target": target, "dataproducts": dataproducts, "data_type": data_type}


### PR DESCRIPTION
- Designed and implemented a templatetag to fetch dataproducts.
- Added support for filtering by data type for visualization.

[Jira Ticket: GOATS-489](https://noirlab.atlassian.net/browse/GOATS-489)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [ ] Maintained or improved the current test coverage.