### PR TITLE
GOATS-505: Change url to relative url when plotting.

### DIFF
--- a/doc/changes/GOATS-505.bugfix.md
+++ b/doc/changes/GOATS-505.bugfix.md
@@ -1,0 +1,1 @@
+Fixed issue with url for fetching and plotting data.

--- a/src/goats_setup/templates/goats_setup/settings.tmpl
+++ b/src/goats_setup/templates/goats_setup/settings.tmpl
@@ -366,13 +366,10 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend']
 }
-CORS_ALLOW_ALL_ORIGINS = True
 CORS_ORIGIN_REGEX_WHITELIST = [
     r"^chrome-extension://[a-zA-Z0-9-]+$",
     r"^moz-extension://[a-zA-Z0-9-]+$",
 ]
-
-
 
 # Default Plotly theme setting, can set to any valid theme:
 # 'plotly', 'plotly_white', 'plotly_dark', 'ggplot2', 'seaborn', 'simple_white', 'none'

--- a/src/goats_tom/templates/tom_targets/target_detail.html
+++ b/src/goats_tom/templates/tom_targets/target_detail.html
@@ -158,13 +158,14 @@
 
   // Helper function to fetch reduced data.
   const fetchReducedData = async (dataproductId, dataType) => {
-    const url = `http://localhost:8000/api/reduceddatums/?data_product=${dataproductId}&data_type=${dataType}`;
+    const url = `/api/reduceddatums/?data_product=${dataproductId}&data_type=${dataType}`;
     const response = await fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
         "X-CSRFToken": "{{ csrf_token }}",
       },
+      credentials: "same-origin",
     });
     if (!response.ok) {
       throw new Error(`Fetch failed with status: ${response.status}`);
@@ -175,13 +176,14 @@
 
   // Helper function to run the processor.
   const runProcessor = async (dataproductId, dataType) => {
-    const url = `http://localhost:8000/api/runprocessor/`;
+    const url = `/api/runprocessor/`;
     const response = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-CSRFToken": "{{ csrf_token }}",
       },
+      credentials: "same-origin",
       body: JSON.stringify({
         data_product: dataproductId,
         data_product_type: dataType,


### PR DESCRIPTION
- Removed hack for CORS.
- Include credentials for same origin.

[Jira Ticket: GOATS-505](https://noirlab.atlassian.net/browse/GOATS-505)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.