### PR TITLE
GOATS-510: Update plot with axis unit handling and editable labels.

### DIFF
--- a/doc/changes/GOATS-510.new.md
+++ b/doc/changes/GOATS-510.new.md
@@ -1,0 +1,1 @@
+Update plot with axis unit handling and editable labels: Added support to display correct units for Wavelength and Flux if available in FITS files. Defaulted to "Wavelength" and "Flux" when units are missing. Made axis labels editable for manual input with CSV files for both photometry and spectroscopy.

--- a/src/goats_tom/templates/partials/dataproduct_visualizer.html
+++ b/src/goats_tom/templates/partials/dataproduct_visualizer.html
@@ -16,6 +16,7 @@
   <div class="row g-3">
     <div class="col-12">
       <div id="{{ data_type }}Plot" class="plotly-container"></div>
+      <figcaption class="figure-caption text-center mt-2">Click on labels to edit text.</figcaption>
     </div>
     <div class="col-12">
       <div style="overflow-y: auto; height: 400px">

--- a/src/goats_tom/templates/tom_targets/target_detail.html
+++ b/src/goats_tom/templates/tom_targets/target_detail.html
@@ -208,11 +208,43 @@
       const wavelength = result.value.wavelength;
       const flux = result.value.flux;
       const timestamp = result.timestamp;
+      const wavelengthUnits = result.value.wavelength_units;
+      const fluxUnits = result.value.flux_units;
 
       if (!wavelength || !flux) {
         return;
       }
 
+      const plottingConfig = plottingConfigurations.get("spectroscopy");
+      const defaultFluxTitle = plottingConfig.layout.yaxis.title;
+      const defaultWavelengthTitle = plottingConfig.layout.xaxis.title;
+
+      // Build axis labels.
+      const newWavelengthLabel = `Wavelength${wavelengthUnits ? ` (${wavelengthUnits})` : ""}`;
+      const newFluxLabel = `Flux${fluxUnits ? ` (${fluxUnits})` : ""}`;
+
+      // Check if axes need updating.
+      if (!plottingConfig.wavelengthUnits || !plottingConfig.fluxUnits) {
+        plottingConfig.wavelengthUnits = wavelengthUnits || "";
+        plottingConfig.fluxUnits = fluxUnits || "";
+        Plotly.relayout(plotId, {
+          "xaxis.title.text": newWavelengthLabel,
+          "yaxis.title.text": newFluxLabel,
+        });
+      } else if (
+        plottingConfig.wavelengthUnits !== wavelengthUnits ||
+        plottingConfig.fluxUnits !== fluxUnits
+      ) {
+        // Mismatch in units, reset to default and show alert.
+        plottingConfig.wavelengthUnits = "";
+        plottingConfig.fluxUnits = "";
+        Plotly.relayout(plotId, {
+          "xaxis.title.text": "Wavelength",
+          "yaxis.title.text": "Flux",
+        });
+        showAlert("", "Mismatch in units, removing label.", "warning");
+      }
+      // Add trace to the plot.
       const trace = {
         x: wavelength,
         y: flux,
@@ -221,8 +253,9 @@
       };
 
       Plotly.addTraces(plotId, trace);
-      if (!plottingConfigurations.get("spectroscopy").initialized) {
-        plottingConfigurations.get("spectroscopy").initialized = true;
+
+      if (!plottingConfig.initialized) {
+        plottingConfig.initialized = true;
       }
     });
   };
@@ -392,10 +425,11 @@
       "spectroscopy",
       {
         initialized: false,
+        wavelengthUnits: null,
+        fluxUnits: null,
         plotFunction: plotSpectroscopy,
         dummyTraces: [],
         layout: {
-          title: "",
           xaxis: {
             title: "Wavelength",
             tickformat: "d",
@@ -425,7 +459,6 @@
           },
         ],
         layout: {
-          title: "",
           xaxis: {
             title: "Time (MJD)",
             tickformat: ".2f",
@@ -472,6 +505,7 @@
           displayModeBar: true,
           displayLogo: false,
           responsive: true,
+          editable: true,
         }
       );
 


### PR DESCRIPTION
- Display correct units for Wavelength and Flux if available in FITS files.
- Default to “Wavelength” and “Flux” when units are missing.
- Enable editable axis labels for manual unit input with CSV files.

[Jira Ticket: GOATS-510](https://noirlab.atlassian.net/browse/GOATS-510)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.