### PR TITLE
GOATS-524: Improve cancel functionality for DRAGONS reduction.

### DIFF
--- a/doc/changes/GOATS-524.new.md
+++ b/doc/changes/GOATS-524.new.md
@@ -1,0 +1,1 @@
+Improve cancel functionality: Enabled multiple attempts to stop background tasks during DRAGONS reduction if the initial cancellation fails.

--- a/src/goats_tom/static/js/dragons_app/recipe_reduction.js
+++ b/src/goats_tom/static/js/dragons_app/recipe_reduction.js
@@ -41,6 +41,7 @@ class RecipeReductionModel {
    */
   async stopReduce() {
     const data = { status: "canceled" };
+    if (!this.currentReduceData) return;
     try {
       const response = await this.api.patch(
         `${this.reducesUrl}${this.currentReduceData.id}/`,
@@ -204,7 +205,7 @@ class RecipeReductionTemplate {
     startButton.textContent = "Start";
     stopButton.textContent = "Stop";
     stopButton.dataset.action = "stopReduce";
-    stopButton.disabled = true;
+    stopButton.disabled = false;
     col2.append(startButton, stopButton);
 
     // Build the layout.
@@ -546,12 +547,15 @@ class RecipeReductionView {
   _startReduce(data) {
     this.startButton.disabled = true;
     this.stopButton.disabled = false;
+    if (!data) return;
     this._update(data);
   }
 
   _stopReduce(data) {
     this.startButton.disabled = false;
-    this.stopButton.disabled = true;
+    // To let multiple cancels if the first fails.
+    this.stopButton.disabled = false;
+    if (!data) return;
     this._update(data);
   }
 
@@ -564,7 +568,7 @@ class RecipeReductionView {
     this.progress.update(data.status);
     if (["canceled", "done", "error"].includes(data.status)) {
       this.startButton.disabled = false;
-      this.stopButton.disabled = true;
+      this.stopButton.disabled = false;
     } else {
       this.startButton.disabled = true;
       this.stopButton.disabled = false;


### PR DESCRIPTION
- Allow users to retry canceling background tasks if the first stop fails.

[Jira Ticket: GOATS-524](https://noirlab.atlassian.net/browse/GOATS-524)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.