### PR TITLE
GOATS-371: Fix bug with spaces in calibration database paths.

### DIFF
--- a/doc/changes/GOATS-317.bugfix.md
+++ b/doc/changes/GOATS-317.bugfix.md
@@ -1,0 +1,1 @@
+Fixed calibration path handling: Resolved issue with spaces in calibration database paths causing errors during DRAGONS reduction.

--- a/src/goats_tom/api_views/dragons_runs.py
+++ b/src/goats_tom/api_views/dragons_runs.py
@@ -105,7 +105,7 @@ class DRAGONSRunsViewSet(
 
         # Write the DRAGONS config file.
         with config_file.open("w") as f:
-            f.write(f"[calibs]\ndatabases = {cal_manager_db_file} get store")
+            f.write(f"[calibs]\ndatabases = \"{cal_manager_db_file}\" get store")
 
         # Create the calibration manager for DRAGONS.
         cal_db = cal_service.LocalDB(cal_manager_db_file, force_init=True)


### PR DESCRIPTION
- Wrap calibration database path in quotes to fix.

[Jira Ticket: GOATS-317](https://noirlab.atlassian.net/browse/GOATS-317)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [x] Added or reviewed a release note in `doc/changes`.
- [x] Maintained or improved the current test coverage.