### PR TITLE
GOATS-559: Fix file deletion bug for processed files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ docs/_build/
 .pybuilder/
 target/
 
+# pytest profiling
+prof/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/doc/changes/GOATS-559.bugfix.md
+++ b/doc/changes/GOATS-559.bugfix.md
@@ -1,0 +1,1 @@
+Fixed file deletion bug: Correctly built full path for processed files to delete.

--- a/src/goats_tom/models/dragons_run.py
+++ b/src/goats_tom/models/dragons_run.py
@@ -8,6 +8,7 @@ from importlib import metadata
 from pathlib import Path
 
 from django.conf import settings
+from django.core.files.storage import default_storage
 from django.db import models
 from recipe_system import cal_service
 from tom_dataproducts.models import DataProduct
@@ -346,18 +347,6 @@ class DRAGONSRun(models.Model):
         finally:
             self.close_caldb(caldb)
 
-    def remove_output_file(self, filename: str) -> None:
-        """Removes the filename from the output directory.
-
-        Parameters
-        ----------
-        filename : `str`
-            The filename to remove.
-
-        """
-        filepath = self.get_output_dir() / filename
-        self.remove_file(filepath)
-
     def remove_file(self, filepath: Path) -> None:
         """Removes a file and removes it from caldb if it exists.
 
@@ -367,8 +356,9 @@ class DRAGONSRun(models.Model):
             Path to the file.
         """
         try:
+            full_path = Path(default_storage.path(str(filepath)))
             filename = filepath.name
-            filepath.unlink()
+            full_path.unlink()
             self.check_and_remove_caldb_file(filename)
 
         except OSError as e:


### PR DESCRIPTION
- Add to gitignore to omit pytest profile folders.

[Jira Ticket: GOATS-559](https://noirlab.atlassian.net/browse/GOATS-559)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.