### PR TITLE
GOATS-579: Set astroquery version to ensure SIMBAD query compatibility.

### DIFF
--- a/ci_environment.yml
+++ b/ci_environment.yml
@@ -21,6 +21,7 @@ channels:
 
 dependencies:
   - astropy>=5.3.3,<6  # Required for tomtoolkit.
+  - astroquery=0.4.7  # SIMBAD bug in 0.4.8.
   - dragons=3.2.3
   - ds9
   - python-confluent-kafka=1.7.0  # Required for linking librdkafka in conda.

--- a/doc/changes/GOATS-579.bugfix.md
+++ b/doc/changes/GOATS-579.bugfix.md
@@ -1,0 +1,1 @@
+Set astroquery version: Fixed SIMBAD query compatibility by pinning astroquery to a working version.

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ channels:
 
 dependencies:
   - astropy>=5.3.3,<6  # Required for tomtoolkit.
+  - astroquery=0.4.7  # SIMBAD bug in 0.4.8.
   - dragons=3.2.3
   - ds9
   - python-confluent-kafka=1.7.0  # Required for linking librdkafka in conda.


### PR DESCRIPTION
[Jira Ticket: GOATS-579](https://noirlab.atlassian.net/browse/GOATS-579)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.