### PR TITLE
GOATS-577: Handle duplicate file entries in checksum files.

### DIFF
--- a/doc/changes/GOATS-577.bugfix.md
+++ b/doc/changes/GOATS-577.bugfix.md
@@ -1,0 +1,1 @@
+Handle duplicate file entries in checksum files: Fixed an issue where duplicate file entries in GOA checksum files caused errors during downloading and decompression. The process now skips duplicates and continues without interruption.

--- a/src/goats_tom/astroquery/gemini.py
+++ b/src/goats_tom/astroquery/gemini.py
@@ -899,13 +899,17 @@ class ObservationsClass(QueryWithLogin):
         md5sums_path = extract_dir / "md5sums.txt"
 
         # Get names of files downloaded.
-        downloaded_files = []
+        downloaded_files = set()
         if md5sums_path.exists():
             with open(md5sums_path) as file:
                 for line in file:
                     parts = line.strip().split()
                     if len(parts) == 2:
-                        downloaded_files.append(parts[1])
+                        filename = parts[1]
+                        if filename in downloaded_files:
+                            print(f"Duplicate file detected in md5sums: {filename}")
+                        # Set ignores duplicates.
+                        downloaded_files.add(filename)
 
         # Get number of files downloaded.
         num_files_downloaded = len(downloaded_files)
@@ -937,7 +941,7 @@ class ObservationsClass(QueryWithLogin):
                         break
 
         download_info = {
-            "downloaded_files": downloaded_files,
+            "downloaded_files": list(downloaded_files),
             "num_files_downloaded": num_files_downloaded,
             "num_files_omitted": num_files_omitted,
             "message": message,

--- a/src/goats_tom/astroquery/urlhelper.py
+++ b/src/goats_tom/astroquery/urlhelper.py
@@ -176,4 +176,6 @@ class URLHelper:
         if orderby is not None:
             query_string = f"?orderby={orderby}"
 
+        print(f"{self.server}{path}{query_string}")
+
         return f"{self.server}{path}{query_string}"


### PR DESCRIPTION
- Skip duplicate file entries in GOA checksum files to avoid errors.
- Ensure downloading and decompression processes continue uninterrupted.

[Jira Ticket: GOATS-577](https://noirlab.atlassian.net/browse/GOATS-577)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.