### PR TITLE
GOATS-428: Add delete run functionality to DRAGONS.

### DIFF
--- a/doc/changes/GOATS-428.new.md
+++ b/doc/changes/GOATS-428.new.md
@@ -1,0 +1,1 @@
+Add delete run functionality: Enabled a delete button for DRAGONS runs, allowing users to reclaim disk space. Extended the API to support run deletions.

--- a/src/goats_tom/api_views/dragons_runs.py
+++ b/src/goats_tom/api_views/dragons_runs.py
@@ -105,7 +105,7 @@ class DRAGONSRunsViewSet(
 
         # Write the DRAGONS config file.
         with config_file.open("w") as f:
-            f.write(f"[calibs]\ndatabases = \"{cal_manager_db_file}\" get store")
+            f.write(f'[calibs]\ndatabases = "{cal_manager_db_file}" get store')
 
         # Create the calibration manager for DRAGONS.
         cal_db = cal_service.LocalDB(cal_manager_db_file, force_init=True)
@@ -229,3 +229,16 @@ class DRAGONSRunsViewSet(
                 data["groups"] = instance.list_groups()
 
         return Response(data)
+
+    def perform_destroy(self, instance: DRAGONSRun) -> None:
+        """Handle the deletion of a DRAGONS run instance and its associated output
+        directory.
+
+        Parameters
+        ----------
+        instance : `DRAGONSRun`
+            The instance of the run.
+        """
+        # Delete the output directory.
+        instance.remove_output_dir()
+        super().perform_destroy(instance)

--- a/src/goats_tom/models/dragons_run.py
+++ b/src/goats_tom/models/dragons_run.py
@@ -3,6 +3,7 @@
 __all__ = ["DRAGONSRun"]
 
 import datetime
+import shutil
 import subprocess
 from importlib import metadata
 from pathlib import Path
@@ -22,10 +23,7 @@ def get_dragons_version():
         # FIXME: Remove this conda subprocess when DRAGONS updates.
         # Run 'conda list dragons' and capture the output.
         result = subprocess.run(
-            ["conda", "list", "dragons"],
-            capture_output=True,
-            text=True,
-            check=True
+            ["conda", "list", "dragons"], capture_output=True, text=True, check=True
         )
         # Parse the output to find the version.
         for line in result.stdout.splitlines():
@@ -154,6 +152,15 @@ class DRAGONSRun(models.Model):
 
         """
         return self.get_raw_dir() / self.output_directory
+
+    def remove_output_dir(self) -> None:
+        """Removes the output directory and its contents recursively."""
+        output_dir = self.get_output_dir()
+        if output_dir.exists():
+            try:
+                shutil.rmtree(output_dir)
+            except Exception as e:
+                print(f"Error deleting output directory {output_dir}: {e}")
 
     def get_cal_manager_db_file(self) -> Path:
         """Returns the full path to the calibration manager database file.

--- a/src/goats_tom/static/js/dragons_app/api.js
+++ b/src/goats_tom/static/js/dragons_app/api.js
@@ -26,7 +26,8 @@ class API {
    * Performs a fetch request with default settings and error handling.
    * @param {string} endpoint - The endpoint to append to the base URL.
    * @param {Object} [options={}] - Additional options for the fetch request.
-   * @returns {Promise<Object>} - A promise resolving to the response data.
+   * @returns {Promise<Object|null>} - A promise resolving to the parsed JSON data or `null` for 
+   * empty responses.
    */
   async request(endpoint, options = {}) {
     const url = `${this.baseUrl}${endpoint}`;
@@ -46,9 +47,12 @@ class API {
         throw response;
       }
 
-      const data = await response.json();
-
-      return data;
+      // Check if the response has a JSON content-type or is empty.
+      const contentType = response.headers.get("Content-Type");
+      if (contentType && contentType.includes("application/json")) {
+        return await response.json();
+      }
+      return null;
     } catch (error) {
       throw error;
     }

--- a/src/goats_tom/static/js/dragons_app/recipe_reduction.js
+++ b/src/goats_tom/static/js/dragons_app/recipe_reduction.js
@@ -825,7 +825,6 @@ class RecipeReductionController {
   async _resetRecipe() {
     const data = await this.model.updateFunctionDefinitionAndUparms();
     this.view.render("updateRecipe", { data });
-    // TODO:
   }
 
   /**


### PR DESCRIPTION
- Implement a delete button for runs to reclaim disk space.
- Extend the API to support run deletions.

[Jira Ticket: GOATS-428](https://noirlab.atlassian.net/browse/GOATS-428)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.