### PR TITLE
GOATS-587: Open browser when starting GOATS.

### DIFF
--- a/doc/changes/GOATS-587.new.md
+++ b/doc/changes/GOATS-587.new.md
@@ -1,0 +1,1 @@
+Open browser on GOATS start: GOATS now opens in the default browser when launched. Users can specify a browser via CLI, and if none is given, the system default is used.

--- a/src/goats_cli/process_manager.py
+++ b/src/goats_cli/process_manager.py
@@ -59,11 +59,12 @@ class ProcessManager:
         """
         process = self.processes.pop(name, None)
         display_message(f"Stopping {name}.")
+
         if process:
             process.terminate()
             try:
                 process.wait(timeout=self.timeout)
-            except subprocess.TimeoutExpired:
+            except Exception:
                 display_warning(f"Could not stop {name} in time, killing {name}.")
                 process.kill()
 

--- a/tests/unit/goats_cli/test_cli.py
+++ b/tests/unit/goats_cli/test_cli.py
@@ -1,6 +1,10 @@
 import click.testing
 import pytest
 from goats_cli import cli
+import requests
+from unittest.mock import patch, MagicMock
+from goats_cli.cli import wait_until_responsive, open_browser, parse_addrport, DEFAULT_HOST
+import webbrowser
 
 
 @pytest.fixture()
@@ -11,3 +15,61 @@ def runner():
 def test_cli_succeeds_without_subcommand(runner):
     result = runner.invoke(cli)
     assert result.exit_code == 0
+import itertools
+
+
+@pytest.mark.parametrize("side_effect, expected", [
+    ([MagicMock(status_code=200)], True),  # Server is immediately responsive.
+    ([requests.exceptions.ConnectionError()] * 2 + [MagicMock(status_code=200)], True),  # Fails 2 times, then works.
+    (itertools.cycle([requests.exceptions.ConnectionError()]), False)  # Always fails.
+])
+def test_wait_until_responsive(side_effect, expected):
+    url = "http://localhost:8000"
+    with patch("requests.get", side_effect=side_effect) as mock_get:
+        result = wait_until_responsive(url, timeout=2, retry_interval=0.1)
+        assert result == expected
+
+
+@pytest.mark.parametrize("browser_choice, get_raises, expected_warning", [
+    ("default", False, None),  # Default browser opens successfully.
+    ("firefox", False, None),  # Specific browser opens successfully.
+    ("chrome", True, "Failed to open browser 'chrome'"),  # Specified browser fails.
+])
+def test_open_browser(browser_choice, get_raises, expected_warning, capsys):
+    url = "http://localhost:8000"
+    with patch("webbrowser.get") as mock_get, patch("webbrowser.open_new") as mock_open:
+        if get_raises:
+            mock_get.side_effect = webbrowser.Error("Browser not found")
+
+        open_browser(url, browser_choice)
+
+        if browser_choice == "default":
+            mock_open.assert_called_once_with(url)
+        else:
+            mock_get.assert_called_once_with(browser_choice)
+            if not get_raises:
+                mock_get.return_value.open_new.assert_called_once_with(url)
+
+        if expected_warning:
+            captured = capsys.readouterr()
+            assert expected_warning in captured.out or captured.err
+            
+
+@pytest.mark.parametrize("addrport, expected", [
+    ("localhost:8000", ("localhost", 8000)),  # Valid hostname.
+    ("127.0.0.1:8080", ("127.0.0.1", 8080)),  # Valid IP address.
+    ("0.0.0.0:5000", ("0.0.0.0", 5000)),  # Valid 0.0.0.0 binding.
+    ("8000", (DEFAULT_HOST, 8000)),  # Default host.
+])
+def test_parse_addrport_valid(addrport, expected, monkeypatch):
+    assert parse_addrport(addrport) == expected
+
+@pytest.mark.parametrize("addrport", [
+    "localhost",  # Missing port.
+    "localhost:",  # Empty port.
+    "bad_address:xyz",  # Non-numeric port.
+    ":8000",  # Missing host.
+])
+def test_parse_addrport_invalid(addrport):
+    with pytest.raises(ValueError, match=f"Invalid addrport format: '{addrport}'"):
+        parse_addrport(addrport)


### PR DESCRIPTION
- Open default browser or user-specified browser on launch.
- Extend CLI to allow specifying a browser.
- Improve subprocess termination.

[Jira Ticket: GOATS-587](https://noirlab.atlassian.net/browse/GOATS-587)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.