### PR TITLE
GOATS-562: Add link to DRAGONS documentation in reduction app.

### DIFF
--- a/doc/changes/GOATS-562.new.md
+++ b/doc/changes/GOATS-562.new.md
@@ -1,0 +1,1 @@
+Add DRAGONS docs link: Linked to the DRAGONS documentation based on the installed version in the reduction app. Defaults to the base documentation if no version is found.

--- a/src/goats_tom/static/js/dragons_app/run_table.js
+++ b/src/goats_tom/static/js/dragons_app/run_table.js
@@ -13,14 +13,13 @@ const KEYS_TO_DISPLAY = [
  */
 class RunTableTemplate {
   createContainer() {
-    const container = Utils.createElement("div");
+    const container = Utils.createElement("div", "table-responsive");
     return container;
   }
 
   create() {
     const container = this.createContainer();
     container.appendChild(this.createTable());
-
     return container;
   }
   /**
@@ -73,6 +72,26 @@ class RunTableTemplate {
         tbody.appendChild(tr);
       }
     });
+
+    // Determine the documentation URL.
+    const dragonsDocsUrl = "https://dragons.readthedocs.io/en";
+    const docsUrl = data["version"]
+      ? `${dragonsDocsUrl}/v${data["version"]}/`
+      : dragonsDocsUrl;
+
+    // Create a row for the documentation link.
+    const docRow = Utils.createElement("tr");
+    const docCell = Utils.createElement("td");
+    docCell.setAttribute("colspan", "2");
+
+    const docLink = Utils.createElement("a");
+    docLink.href = docsUrl;
+    docLink.setAttribute("target", "_blank");
+    docLink.textContent = "View DRAGONS Documentation";
+
+    docCell.appendChild(docLink);
+    docRow.appendChild(docCell);
+    tbody.appendChild(docRow);
 
     return tbody;
   }


### PR DESCRIPTION
- Generate documentation URL based on the installed DRAGONS version.
- Default to the base documentation if no version is available.

[Jira Ticket: GOATS-562](https://noirlab.atlassian.net/browse/GOATS-562)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.