### PR TITLE
GOATS-192: Disable GOA query for incomplete observations.

### DIFF
--- a/doc/changes/GOATS-192.change.md
+++ b/doc/changes/GOATS-192.change.md
@@ -1,0 +1,1 @@
+Disable GOA query for incomplete observations: Prevented users from submitting a GOA query if the observation status was not "Observed". Added a backend check to issue a warning if the restriction is bypassed.

--- a/src/goats_tom/templates/partials/goa_query.html
+++ b/src/goats_tom/templates/partials/goa_query.html
@@ -88,7 +88,17 @@
     <input type="hidden" name="facility" value="{{ object.facility }}">
     <div class="row">
       <div class="col text-center">
-        <button type="submit" class="btn btn-primary">Submit</button>
+        <button 
+          type="submit" 
+          class="btn btn-primary"
+          {% if object.status.lower != "observed" %} disabled {% endif %}
+        >
+          {% if object.status.lower != "observed" %}
+            Observation incomplete. Update status to enable.
+          {% else %}
+            Submit
+          {% endif %}
+        </button>
       </div>
     </div>
   </form>

--- a/src/goats_tom/views/goa_query_form.py
+++ b/src/goats_tom/views/goa_query_form.py
@@ -34,6 +34,21 @@ class GOAQueryFormView(View):
         # Check if your GOAQueryForm was submitted.
         form = GOAQueryForm(request.POST)
         observation_record = ObservationRecord.objects.get(pk=kwargs["pk"])
+        observation_detail_url = reverse(
+            "tom_observations:detail", kwargs={"pk": kwargs["pk"]}
+        )
+
+        # Check if the observation status is valid, if not stop here and issue message.
+        if observation_record.status.lower() != "observed":
+            messages.error(
+                request,
+                (
+                    "GOA data is unavailable until the observation is complete. Update "
+                    "the observation status on the overview page once it's finished."
+                ),
+            )
+            return redirect(observation_detail_url)
+
         if form.is_valid():
             # Get GOA credentials.
             prop_data_msg = "Proprietary data will not be downloaded."
@@ -77,4 +92,4 @@ class GOAQueryFormView(View):
                     msg = f"Error in {field}: {error}"
                     messages.error(request, msg)
 
-        return redirect(reverse("tom_observations:detail", kwargs={"pk": kwargs["pk"]}))
+        return redirect(observation_detail_url)

--- a/tests/unit/goats_tom/views/test_views.py
+++ b/tests/unit/goats_tom/views/test_views.py
@@ -381,7 +381,7 @@ class GOAQueryFormViewTest(TestCase):
         self.user = User.objects.create_user(username="testuser", password="password")
         self.target = SiderealTargetFactory.create()
         self.observation_record = ObservingRecordFactory.create(
-            target_id=self.target.id,
+            target_id=self.target.id, status="Observed"
         )
         self.url = reverse("goa_query", kwargs={"pk": self.observation_record.pk})
         self.form_data = {"download_calibrations": "yes", "facility": "test_facility"}


### PR DESCRIPTION
- Disable the submit button if the observation status is not "Observed".
- Add a backend check to issue a warning if the restriction is bypassed.

[Jira Ticket: GOATS-192](https://noirlab.atlassian.net/browse/GOATS-192)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.