### PR TITLE
GOATS-613: Add API backend to send data to Astro Datalab.

### DIFF
--- a/doc/changes/GOATS-613.new.md
+++ b/doc/changes/GOATS-613.new.md
@@ -1,0 +1,1 @@
+Added API backend for Astro Datalab: Allowed users to send data files to Astro Datalab with their credentials.

--- a/src/goats_tom/api_views/__init__.py
+++ b/src/goats_tom/api_views/__init__.py
@@ -1,4 +1,5 @@
 from .antares2goats import Antares2GoatsViewSet
+from .astro_datalab import AstroDatalabViewSet
 from .base_recipe import BaseRecipeViewSet
 from .dataproducts import DataProductsViewSet
 from .dragons_caldb import DRAGONSCaldbViewSet
@@ -25,5 +26,6 @@ __all__ = [
     "Antares2GoatsViewSet",
     "RunProcessorViewSet",
     "DRAGONSDataViewSet",
-    "ReducedDatumViewSet"
+    "ReducedDatumViewSet",
+    "AstroDatalabViewSet",
 ]

--- a/src/goats_tom/api_views/astro_datalab.py
+++ b/src/goats_tom/api_views/astro_datalab.py
@@ -1,0 +1,90 @@
+"""Handles adding a file to Astro Datalab"""
+
+__all__ = ["AstroDatalabViewSet"]
+
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+from dl import authClient as ac
+from dl import storeClient as sc
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet, mixins
+from tom_dataproducts.models import DataProduct
+
+from goats_tom.serializers import AstroDatalabSerializer
+
+ASTRO_DATALAB_DIR = "vos://goats_data"
+
+
+class AstroDatalabViewSet(GenericViewSet, mixins.CreateModelMixin):
+    serializer_class = AstroDatalabSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    queryset = None
+
+    def create(self, request: HttpRequest, *args, **kwargs) -> Response:
+        """Handle the request to upload a file to Astro Data Lab.
+
+        This method validates the provided `data_product` and triggers the upload
+        process.
+
+        Parameters
+        ----------
+        request : `HttpRequest`
+            The HTTP request containing the `data_product` ID to be uploaded.
+
+        Returns
+        -------
+        `Response`
+            - 201: If the file was successfully uploaded.
+            - 400: If an error occurred during the upload process.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        data_product = serializer.validated_data["data_product"]
+
+        try:
+            self.send_to_astro_datalab(request.user, data_product)
+
+        except Exception as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(
+            {
+                "message": f"File {data_product.data.name} successfully sent to "
+                f"'{ASTRO_DATALAB_DIR}' on Astro Datalab.",
+                "data_product": data_product.id,
+            },
+            status.HTTP_201_CREATED,
+        )
+
+    def send_to_astro_datalab(self, user: User, data_product: DataProduct) -> None:
+        """Handles authentication and file upload to Astro Data Lab.
+
+        Parameters
+        ----------
+        user : `User`
+            The authenticated user making the request.
+        data_product : `DataProduct`
+            The data product to be uploaded.
+
+        Raises
+        ------
+        ValueError
+            Raised if authentication fails or an error occurs during file upload.
+        """
+        astro_datalab_login = user.astrodatalablogin
+        token = ac.login(astro_datalab_login.username, astro_datalab_login.password)
+        if not ac.isValidToken(token):
+            raise ValueError("Astro Datalab credentials are not valid.")
+        try:
+            # Create the directory, better to try then check and try as less API calls.
+            sc.mkdir(token, ASTRO_DATALAB_DIR)
+            # Put the file on Astro Datalab.
+            sc.put(token, to=ASTRO_DATALAB_DIR, fr=data_product.data.path)
+        finally:
+            try:
+                ac.logout(token)
+            except Exception:
+                pass

--- a/src/goats_tom/serializers/__init__.py
+++ b/src/goats_tom/serializers/__init__.py
@@ -1,4 +1,5 @@
 from .antares2goats import Antares2GoatsSerializer
+from .astro_datalab import AstroDatalabSerializer
 from .base_recipe import BaseRecipeSerializer
 from .dataproduct import DataProductSerializer
 from .dataproduct_metadata import DataProductMetadataSerializer
@@ -35,4 +36,5 @@ __all__ = [
     "DataProductMetadataSerializer",
     "Antares2GoatsSerializer",
     "HeaderSerializer",
+    "AstroDatalabSerializer",
 ]

--- a/src/goats_tom/serializers/astro_datalab.py
+++ b/src/goats_tom/serializers/astro_datalab.py
@@ -1,0 +1,14 @@
+"""Module to serialize/deserialize file to send to Astro Datalab."""
+
+__all__ = ["AstroDatalabSerializer"]
+
+from rest_framework import serializers
+from tom_dataproducts.models import DataProduct
+
+
+class AstroDatalabSerializer(serializers.Serializer):
+    data_product = serializers.PrimaryKeyRelatedField(
+        queryset=DataProduct.objects.all(),
+        required=True,
+        help_text="The ID of the DataProduct to send to Astro Datalab.",
+    )

--- a/src/goats_tom/urls.py
+++ b/src/goats_tom/urls.py
@@ -34,6 +34,7 @@ router.register(r"runprocessor", api_views.RunProcessorViewSet, basename="runpro
 router.register(
     r"antares2goats", api_views.Antares2GoatsViewSet, basename="antares2goats"
 )
+router.register(r"astrodatalab", api_views.AstroDatalabViewSet, basename="astrodatalab")
 # TODO: Add app_name and update paths and URL lookups.
 # TODO: Make unified path formats.
 

--- a/tests/unit/goats_tom/api_views/test_astro_datalab_api_view.py
+++ b/tests/unit/goats_tom/api_views/test_astro_datalab_api_view.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework import status
+
+from goats_tom.api_views import AstroDatalabViewSet
+from goats_tom.tests.factories import DataProductFactory, UserFactory
+
+
+class AstroDatalabViewSetTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data."""
+        cls.factory = APIRequestFactory()
+        cls.user = UserFactory()
+        cls.data_product = DataProductFactory()
+
+    @patch.object(AstroDatalabViewSet, "send_to_astro_datalab")
+    def test_create_calls_send_to_astro_datalab(self, mock_send_to_astro_datalab):
+        """Test that create() calls send_to_astro_datalab with the correct arguments."""
+        view = AstroDatalabViewSet.as_view({"post": "create"})
+        request = self.factory.post(
+            "/astro-datalab/", {"data_product": self.data_product.id}, format="json"
+        )
+        force_authenticate(request, user=self.user)
+        request.user = self.user
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_send_to_astro_datalab.assert_called_once_with(self.user, self.data_product)
+
+    @patch.object(AstroDatalabViewSet, "send_to_astro_datalab", side_effect=Exception("Upload failed"))
+    def test_create_handles_send_to_astro_datalab_exception(self, mock_send_to_astro_datalab):
+        """Test handle exceptions from send_to_astro_datalab gracefully."""
+        view = AstroDatalabViewSet.as_view({"post": "create"})
+        request = self.factory.post(
+            "/astro-datalab/", {"data_product": self.data_product.id}, format="json"
+        )
+        force_authenticate(request, user=self.user)
+        request.user = self.user
+
+        response = view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "Upload failed")

--- a/tests/unit/goats_tom/serializers/test_astro_datalab_serializer.py
+++ b/tests/unit/goats_tom/serializers/test_astro_datalab_serializer.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from goats_tom.tests.factories import DataProductFactory
+from goats_tom.serializers import AstroDatalabSerializer
+
+
+class AstroDatalabSerializerTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data."""
+        cls.data_product = DataProductFactory()
+
+    def test_valid_data(self):
+        """Test serializer with valid data_product ID."""
+        valid_data = {"data_product": self.data_product.id}
+        serializer = AstroDatalabSerializer(data=valid_data)
+        self.assertTrue(serializer.is_valid(), msg=serializer.errors)
+
+    def test_invalid_data_product(self):
+        """Test serializer with invalid (nonexistent) data_product ID."""
+        invalid_data = {"data_product": 2}
+        serializer = AstroDatalabSerializer(data=invalid_data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("data_product", serializer.errors)


### PR DESCRIPTION
- Allow users to upload data files using their credentials.

[Jira Ticket: GOATS-613](https://noirlab.atlassian.net/browse/GOATS-613)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.