### PR TITLE
GOATS-628: Replace Astro Data Lab image link with iframe.

### DIFF
--- a/doc/changes/GOATS-628.change.md
+++ b/doc/changes/GOATS-628.change.md
@@ -1,0 +1,1 @@
+iframe support for Astro Data Lab: Replaced static image link with an iframe to display the most recent version of the Astro Data Lab webpage. Added a failsafe text link for accessibility.

--- a/src/goats_tom/templates/astro_datalab.html
+++ b/src/goats_tom/templates/astro_datalab.html
@@ -26,14 +26,18 @@
     </p>
   </div>
   <hr>
-  <div class="col-8 text-center">
-    <p>Click the image to open the Astro Data Lab portal.</p>
-    <a href="https://datalab.noirlab.edu/" target="_blank">
-      <img
-        src="{% static 'img/astro-datalab.png' %}"
-        class="img-fluid"
-        alt="Astro Data Lab" />
-    </a>
+  <div class="col-12 text-center">
+    <p>
+      Click 
+      <a href="https://datalab.noirlab.edu" target="_blank">
+        Astro Data Lab portal
+      </a>
+      or the image below to open it in a new tab.
+    </p>
+    <div class="ratio ratio-1x1 position-relative">
+      <iframe src="https://datalab.noirlab.edu" scrolling="no" style="pointer-events: none;"></iframe>
+      <a href="https://datalab.noirlab.edu" target="_blank" class="stretched-link"></a>
+    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
- Display the most recent version of the Astro Data Lab webpage.
- Add a direct text link as a fallback for accessibility.

[Jira Ticket: GOATS-628](https://noirlab.atlassian.net/browse/GOATS-628)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.