### PR TITLE
GOATS-626: Add code coverage support to github actions.

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -60,4 +60,9 @@ jobs:
       - name: Run tests and calculate coverage
         run: |
           cd goats
-          pytest -r A -v -n auto --cov=src --cov-report=term --cov=tests --cov-branch
+          pytest -r A -v -n auto --cov=src --cov-report=xml --cov=tests --cov-branch
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/doc/changes/GOATS-626.new.md
+++ b/doc/changes/GOATS-626.new.md
@@ -1,0 +1,1 @@
+Added pytest code coverage reporting.

--- a/tests/unit/goats_tom/tests/factories/test_base_recipe.py
+++ b/tests/unit/goats_tom/tests/factories/test_base_recipe.py
@@ -15,4 +15,3 @@ class TestBaseRecipeFactory:
         )
         assert recipe.name == "Test Recipe", "Factory should use the specified name."
         assert recipe.version == "32.2.0", "Factory should use the specified version."
-


### PR DESCRIPTION
[Jira Ticket: GOATS-626](https://noirlab.atlassian.net/browse/GOATS-626)

## Checklist

- [ ] Ran integration tests in Jenkins (if applicable).
- [X] Added or reviewed a release note in `doc/changes`.
- [X] Maintained or improved the current test coverage.