### PR TITLE
GOATS-653 GOATS-660: Develop middleware to cleanly shut down DRAGONS operations in worker threads.

### DIFF
--- a/docs/changes/GOATS-660.new.md
+++ b/docs/changes/GOATS-660.new.md
@@ -1,0 +1,1 @@
+Cleanly shut down DRAGONS in worker threads: Removed leftover orphaned processes on GOATS shutdown using custom middleware.

--- a/src/goats_setup/templates/goats_setup/settings.tmpl
+++ b/src/goats_setup/templates/goats_setup/settings.tmpl
@@ -139,6 +139,7 @@ DRAMATIQ_BROKER = {
         "django_dramatiq.middleware.AdminMiddleware",
         "django_dramatiq.middleware.DbConnectionsMiddleware",
         "dramatiq.middleware.Callbacks",
+        "goats_tom.middleware.DRAGONSMiddleware"
     ]
 }
 DRAMATIQ_ACTOR_TIME_LIMIT = 86400000  # In milliseconds

--- a/src/goats_tom/middleware/__init__.py
+++ b/src/goats_tom/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .dragons import DRAGONSMiddleware
+
+__all__ = ["DRAGONSMiddleware"]

--- a/src/goats_tom/middleware/dragons.py
+++ b/src/goats_tom/middleware/dragons.py
@@ -1,0 +1,48 @@
+__all__ = ["DRAGONSMiddleware"]
+
+from dramatiq import Broker, Worker
+from dramatiq.middleware import Middleware
+from gempy.eti_core.eti import ETISubprocess
+
+
+class DRAGONSMiddleware(Middleware):
+    """Middleware to ensure DRAGONS is properly cleaned up shut down."""
+
+    def before_worker_shutdown(self, broker: Broker, worker: Worker) -> None:
+        """Ensures `DRAGONS.ETISubprocess` is terminated when a Dramatiq worker shuts
+        down.
+
+        Parameters
+        ----------
+        broker : `Broker`
+            The broker managing message processing.
+        worker : `Worker`
+            The worker instance that is shutting down.
+        """
+        print("DRAGONSMiddleware: Terminating DRAGONS subprocesses on worker shutdown.")
+
+        try:
+            eti_subprocess = ETISubprocess()
+            # Send quit message to loop.
+            # Leaving in hoping DRAGONS merges in requested changes.
+            # eti_subprocess.inQueue.put(None)
+            eti_subprocess.process.join(timeout=2)
+
+            # If still alive, force-terminate.
+            if eti_subprocess.process.is_alive():
+                eti_subprocess.process.terminate()
+                eti_subprocess.process.join()
+
+            # Free up resources.
+            eti_subprocess.process.close()
+
+            # Ensure queues are properly closed after the process is dead.
+            try:
+                eti_subprocess.inQueue.close()
+                eti_subprocess.inQueue.join_thread()
+                eti_subprocess.outQueue.close()
+                eti_subprocess.outQueue.join_thread()
+            except Exception:
+                pass
+        except Exception as e:
+            print(f"Error during DRAGONS shutdown: {e}")

--- a/src/goats_tom/tasks/run_dragons_reduce.py
+++ b/src/goats_tom/tasks/run_dragons_reduce.py
@@ -183,6 +183,12 @@ def run_dragons_reduce(reduce_id: int, file_ids: list[int]) -> None:
         )
         raise
     finally:
+        # Remove handler so it can’t emit more log records.
+        # This would cause coroutines to be unawaited.
+        logger = logging.getLogger()
+        for h in logger.handlers[:]:
+            if isinstance(h, DRAGONSHandler):
+                logger.removeHandler(h)
         # Cleanup dynamically created module.
         if module_name in sys.modules:
             del sys.modules[module_name]


### PR DESCRIPTION
- Remove orphaned processes on GOATS shutdown.

[Jira Ticket: GOATS-660](https://noirlab.atlassian.net/browse/GOATS-660)
[Jira Ticket: GOATS-653](https://noirlab.atlassian.net/browse/GOATS-653)

## Checklist

- [X] Added or reviewed a release note in `doc/changes`.
