### PR TITLE
GOATS-654: Ensure worker shutdown in Dramatiq.

### DIFF
--- a/docs/changes/GOATS-654.new.md
+++ b/docs/changes/GOATS-654.new.md
@@ -1,0 +1,1 @@
+Ensured worker shutdown in Dramatiq: Added fallbacks to manage worker threads, ensuring they were terminated if graceful shutdown failed. This prevented orphaned or zombie workers.

--- a/src/goats_cli/cli.py
+++ b/src/goats_cli/cli.py
@@ -421,6 +421,9 @@ def run(
         while True:
             time.sleep(0.1)
 
+    except KeyboardInterrupt:
+        display_warning("Caught Ctrl+C. Running shutdown procedure.")
+
     finally:
         process_manager.stop_all()
 


### PR DESCRIPTION
- Add fallbacks to forcefully terminate workers if graceful shutdown fails.

[Jira Ticket: GOATS-654](https://noirlab.atlassian.net/browse/GOATS-654)

## Checklist

- [X] Added or reviewed a release note in `doc/changes`.
