### PR TITLE
GOATS-655 GOATS-656 GOATS-657: Enforce shutdown return codes and port checks for services.

### DIFF
--- a/docs/changes/GOATS-655.new.md
+++ b/docs/changes/GOATS-655.new.md
@@ -1,0 +1,1 @@
+Shutdown return code and port checks for Redis: Added shutdown return code for Redis and enforced killing child workers if timeout occurs. Checked if ports are in use on startup, issuing an error and preventing startup if occupied.

--- a/docs/changes/GOATS-656.new.md
+++ b/docs/changes/GOATS-656.new.md
@@ -1,0 +1,1 @@
+Shutdown return code and port checks for Django: Added shutdown return code for Django and enforced killing child workers if timeout occurs. Checked if ports are in use on startup, issuing an error and preventing startup if occupied.

--- a/docs/changes/GOATS-657.new.md
+++ b/docs/changes/GOATS-657.new.md
@@ -1,0 +1,1 @@
+Shutdown return code Dramatiq: Added shutdown return code for Dramatiq and enforced killing child workers if timeout occurs.

--- a/src/goats_cli/cli.py
+++ b/src/goats_cli/cli.py
@@ -5,88 +5,20 @@ import re
 import shutil
 import subprocess
 import time
-import webbrowser
 from pathlib import Path
-from typing import IO, Any
 
 import click
-import requests
-from click._compat import get_text_stderr
 
+import goats_cli.utils as utils
+from goats_cli.config import config
+from goats_cli.exceptions import GOATSClickException
 from goats_cli.modify_settings import modify_settings
 from goats_cli.process_manager import ProcessManager
-from goats_cli.utils import (
-    display_failed,
-    display_info,
-    display_message,
-    display_ok,
-    display_warning,
-)
-
-REDIS_HOST: str = "localhost"
-REDIS_PORT: int = 6379
-REDIS_ADDRPORT: str = f"{REDIS_HOST}:{REDIS_PORT}"
-REGEX_PATTERN = r"^(?:(?P<host>[^:]+):)?(?P<port>[0-9]+)$"
-DEFAULT_HOST: str = "localhost"
-DEFAULT_PORT: int = 8000
-DEFAULT_ADDRPORT: str = f"{DEFAULT_HOST}:{DEFAULT_PORT}"
-
-
-def parse_addrport(addrport: str) -> tuple[str, int]:
-    """Parses an address and port string into host and port components.
-
-    Parameters
-    ----------
-    addrport : `str`
-        The address and port string, e.g., "localhost:8000" or "8000".
-
-    Returns
-    -------
-    `tuple[str, int]`
-        A tuple of (host, port), where host is a string and port is an integer.
-
-    Raises
-    ------
-    ValueError
-        If the input does not match the expected format.
-    """
-    pattern = re.compile(REGEX_PATTERN)
-    match = pattern.match(addrport)
-    if not match:
-        raise ValueError(f"Invalid addrport format: '{addrport}'")
-
-    host = match.group("host") or DEFAULT_HOST
-    port = int(match.group("port"))
-    return host, port
-
-
-class GOATSClickException(click.ClickException):
-    """An extension of ClickException to show a goat emoji with the message."""
-
-    def show(self, file: IO[Any] | None = None) -> None:
-        """Display the error message prefixed with a goat emoji.
-
-        If a file object is passed, it writes the message to the file,
-        otherwise, it writes the message to standard error.
-
-        Parameters
-        ----------
-        file : `IO[Any] | None`, optional
-            The file object to write the message to, by default ``None``.
-
-        """
-        if file is None:
-            file = get_text_stderr()
-
-        click.echo(
-            click.style(f"🐐 Error: {self.format_message()}", fg="red", bold=True),
-            file=file,
-        )
 
 
 def validate_addrport(ctx, param, value):
     """Validate IP address and port."""
-    if not re.match(REGEX_PATTERN, value):
+    if not re.match(config.addrport_regex_pattern, value):
         raise click.BadParameter(
             "The address and port must be in format 'HOST:PORT' or 'PORT'.",
         )
@@ -137,7 +69,7 @@ def cli(ctx):
 )
 @click.option(
     "--redis-addrport",
-    default=REDIS_ADDRPORT,
+    default=config.redis_addrport,
     type=str,
     help=(
         "Specify the Redis server IP address and port number. "
@@ -221,7 +153,7 @@ def install(
         if media_dir:
             resolved_media_dir = media_dir.resolve()
             if resolved_media_dir.exists():
-                display_warning(
+                utils.display_warning(
                     "Media root directory already exists, proceeding but existing "
                     "data might conflict."
                 )
@@ -230,8 +162,8 @@ def install(
         subprocess.run(goats_setup_command, check=True)
 
         # Migrate the webpage.
-        display_message("Wrapping up:", show_goats_emoji=False)
-        display_info("Running final migrations... ")
+        utils.display_message("Wrapping up:", show_goats_emoji=False)
+        utils.display_info("Running final migrations... ")
         subprocess.run(
             [f"{manage_file}", "makemigrations"],
             stdout=subprocess.PIPE,
@@ -244,9 +176,9 @@ def install(
             stderr=subprocess.PIPE,
             check=True,
         )
-        display_ok()
+        utils.display_ok()
 
-        display_message("GOATS installed!", color="green")
+        utils.display_message("GOATS installed!", color="green")
 
     except subprocess.CalledProcessError as error:
         cmd_str = " ".join(error.cmd)
@@ -286,7 +218,7 @@ def install(
 )
 @click.option(
     "--addrport",
-    default=DEFAULT_ADDRPORT,
+    default=config.django_addrport,
     type=str,
     help=(
         "Specify the IP address and port number to serve GOATS. "
@@ -297,7 +229,7 @@ def install(
 )
 @click.option(
     "--redis-addrport",
-    default=REDIS_ADDRPORT,
+    default=config.redis_addrport,
     type=str,
     help=(
         "Specify the Redis server IP address and port number. "
@@ -356,20 +288,22 @@ def run(
     GOATSClickException
         Raised if the 'subprocess' calls fail.
     """
-    display_message("Serving GOATS.\n")
-    display_message("Finding GOATS and Redis installation:", show_goats_emoji=False)
-    display_info("Verifying 'manage.py' exists for GOATS...")
+    utils.display_message("Serving GOATS.\n")
+    utils.display_message(
+        "Finding GOATS and Redis installation:", show_goats_emoji=True
+    )
+    utils.display_info("Verifying 'manage.py' exists for GOATS...")
     project_path = directory / project_name
     # Get the path for the 'manage.py' file.
     manage_file = project_path / "manage.py"
     if not manage_file.is_file():
-        display_failed()
+        utils.display_failed()
         raise GOATSClickException(
             f"The 'manage.py' file for the project '{project_name}' does not exist at"
             f" '{manage_file.absolute()}'."
         )
-    display_ok()
-    display_info("Verifying Redis installed...")
+    utils.display_ok()
+    utils.display_info("Verifying Redis installed...")
     try:
         subprocess.run(
             ["redis-server", "--version"],
@@ -377,19 +311,27 @@ def run(
             text=True,
             capture_output=True,
         )
-        display_ok()
+        utils.display_ok()
     except FileNotFoundError:
-        display_failed()
+        utils.display_failed()
         raise GOATSClickException(
             "An error occurred verifying Redis. Is Redis installed?",
         )
 
-    display_message(
+    utils.display_message("Checking for running instances of Redis and GOATS:")
+    time.sleep(2)
+    redis_host, redis_port = utils.parse_addrport(redis_addrport)
+    utils.check_port_not_in_use("Redis", redis_host, redis_port)
+
+    django_host, django_port = utils.parse_addrport(addrport)
+    utils.check_port_not_in_use("Django", django_host, django_port)
+
+    utils.display_message(
         "Starting Redis, GOATS and background workers:",
-        show_goats_emoji=False,
+        show_goats_emoji=True,
     )
-    display_message(
-        "---------------------------------------------",
+    utils.display_message(
+        "-----------------------------------------------",
         show_goats_emoji=False,
     )
     time.sleep(2)
@@ -412,17 +354,16 @@ def run(
         )
 
         # Open the browser.
-        host, port = parse_addrport(addrport)
-        url = f"http://{host}:{port}"
-        if wait_until_responsive(url):
+        url = f"http://{django_host}:{django_port}"
+        if utils.wait_until_responsive(url):
             # Build the url and open it.
-            open_browser(url, browser)
+            utils.open_browser(url, browser)
 
         while True:
             time.sleep(0.1)
 
     except KeyboardInterrupt:
-        display_warning("Caught Ctrl+C. Running shutdown procedure.")
+        utils.display_warning("Caught Ctrl+C. Running shutdown procedure.")
 
     finally:
         process_manager.stop_all()
@@ -447,8 +388,8 @@ def start_redis_server(addrport: str, disable_rdb: bool = True) -> subprocess.Po
         Raised if issue starting Redis server.
 
     """
-    display_message("Starting redis database.")
-    pattern = re.compile(REGEX_PATTERN)
+    utils.display_message("Starting redis database.")
+    pattern = re.compile(config.addrport_regex_pattern)
     match = pattern.match(addrport)
     port = match.group("port")
     cmd = ["redis-server", "--port", f"{port}"]
@@ -487,7 +428,7 @@ def start_django_server(manage_file: Path, addrport: str) -> subprocess.Popen:
         Raised if issue starting Django server.
 
     """
-    display_message("Starting django server.")
+    utils.display_message("Starting django server.")
     try:
         django_process = subprocess.Popen(
             [f"{manage_file}", "runserver", addrport],
@@ -520,7 +461,7 @@ def start_background_workers(manage_file: Path, workers: int) -> subprocess.Pope
         Raised if issue starting background workers.
 
     """
-    display_message("Starting background workers.")
+    utils.display_message("Starting background workers.")
     try:
         background_workers_process = subprocess.Popen(
             [
@@ -541,67 +482,6 @@ def start_background_workers(manage_file: Path, workers: int) -> subprocess.Pope
             f"Exit status: {error.returncode}."
         )
     return background_workers_process
-
-
-def wait_until_responsive(
-    url: str, timeout: int = 30, retry_interval: float = 1.0
-) -> bool:
-    """Waits until the server responds with a valid HTTP status.
-
-    Parameters
-    ----------
-    url : `str`
-        The URL of the server to check.
-    timeout : `int`
-        Maximum time in seconds to wait for the server to respond.
-    retry_interval : `float`
-        Time in seconds to wait between retries (default: 1s).
-
-    Returns
-    -------
-    `bool`
-        `True` if the server is responsive, `False` if the timeout is reached.
-    """
-    start_time = time.time()
-    attempts = 0  # Track how many times we retry
-
-    while time.time() - start_time < timeout:
-        attempts += 1
-        try:
-            response = requests.get(url, timeout=5)
-
-            if response.status_code == 200:
-                return True
-        except Exception:
-            time.sleep(retry_interval)
-
-    display_warning(f"GOATS server did not respond after {attempts} attempts.")
-    display_warning(
-        f"Check if the server is running, then open your browser and go to: {url}"
-    )
-    return False
-
-
-def open_browser(url: str, browser_choice: str) -> None:
-    """Opens the specified browser or defaults to the system browser.
-
-    Parameters
-    ----------
-    url : `str`
-        The URL to open in the browser.
-    browser_choice : `str`
-        The browser choice.
-    """
-    display_message(f"Opening GOATS at {url} in {browser_choice} browser.")
-    try:
-        if browser_choice == "default":
-            webbrowser.open_new(url)
-        else:
-            browser = webbrowser.get(browser_choice)
-            browser.open_new(url)
-    except webbrowser.Error as e:
-        display_warning(f"Failed to open browser '{browser_choice}': {str(e)}.")
-        display_warning(f"Try opening a browser and navigate to: {url}")
 
 
 cli.add_command(install)

--- a/src/goats_cli/config.py
+++ b/src/goats_cli/config.py
@@ -1,0 +1,21 @@
+"""Configuration for CLI."""
+
+__all__ = ["Config", "config"]
+
+from dataclasses import dataclass
+
+
+@dataclass()
+class Config:
+    host: str = "localhost"
+    redis_port: int = 6379
+    django_port: int = 8000
+    addrport_regex_pattern: str = r"^(?:(?P<host>[^:]+):)?(?P<port>[0-9]+)$"
+
+    def __post_init__(self) -> None:
+        """Creates the full address."""
+        self.django_addrport = f"{self.host}:{self.django_port}"
+        self.redis_addrport = f"{self.host}:{self.redis_port}"
+
+
+config = Config()

--- a/src/goats_cli/exceptions.py
+++ b/src/goats_cli/exceptions.py
@@ -1,0 +1,32 @@
+"""Exception that displays for GOATS errors."""
+
+__all__ = ["GOATSClickException"]
+
+from typing import IO, Any
+
+import click
+from click._compat import get_text_stderr
+
+
+class GOATSClickException(click.ClickException):
+    """An extension of ClickException to show a goat emoji with the message."""
+
+    def show(self, file: IO[Any] | None = None) -> None:
+        """Display the error message prefixed with a goat emoji.
+
+        If a file object is passed, it writes the message to the file,
+        otherwise, it writes the message to standard error.
+
+        Parameters
+        ----------
+        file : `IO[Any] | None`, optional
+            The file object to write the message to, by default ``None``.
+
+        """
+        if file is None:
+            file = get_text_stderr()
+
+        click.echo(
+            click.style(f"🐐 Error: {self.format_message()}", fg="red", bold=True),
+            file=file,
+        )

--- a/src/goats_cli/modify_settings.py
+++ b/src/goats_cli/modify_settings.py
@@ -1,4 +1,5 @@
 __all__ = ["modify_settings"]
+
 from pathlib import Path
 
 from goats_cli.plugins import GOATSPlugin, Plugin

--- a/src/goats_cli/utils.py
+++ b/src/goats_cli/utils.py
@@ -6,10 +6,23 @@ __all__ = [
     "display_info",
     "display_failed",
     "display_warning",
+    "port_in_use",
+    "check_port_not_in_use",
+    "parse_addrport",
+    "open_browser",
+    "wait_until_responsive",
 ]
+
+import re
+import socket
 import time
+import webbrowser
 
 import click
+import requests
+
+from goats_cli.config import config
+from goats_cli.exceptions import GOATSClickException
 
 
 def display_message(
@@ -72,3 +85,112 @@ def display_warning(message: str, indent: int = 0) -> None:
     click.echo(
         click.style(f"🐐 WARNING: {' ' * indent}{message}", fg="yellow", bold=True)
     )
+
+
+def port_in_use(host, port) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        return sock.connect_ex((host, port)) == 0
+
+
+def check_port_not_in_use(service_name: str, host: str, port: int) -> None:
+    """
+    Displays logging messages, checks if the given host:port is in use,
+    and raises GOATSClickException if so.
+    """
+    display_info(f"Checking {service_name} on {host}:{port}...")
+    if port_in_use(host, port):
+        display_failed()
+        raise GOATSClickException(
+            f"{service_name} instance already running on {host}:{port}. "
+            "Please stop it before running GOATS again."
+        )
+    display_ok()
+
+
+def parse_addrport(addrport: str) -> tuple[str, int]:
+    """Parses an address and port string into host and port components.
+
+    Parameters
+    ----------
+    addrport : `str`
+        The address and port string, e.g., "localhost:8000" or "8000".
+
+    Returns
+    -------
+    `tuple[str, int]`
+        A tuple of (host, port), where host is a string and port is an integer.
+
+    Raises
+    ------
+    ValueError
+        If the input does not match the expected format.
+    """
+    pattern = re.compile(config.addrport_regex_pattern)
+    match = pattern.match(addrport)
+    if not match:
+        raise ValueError(f"Invalid addrport format: '{addrport}'")
+
+    host = match.group("host") or config.host
+    port = int(match.group("port"))
+    return host, port
+
+
+def wait_until_responsive(
+    url: str, timeout: int = 30, retry_interval: float = 1.0
+) -> bool:
+    """Waits until the server responds with a valid HTTP status.
+
+    Parameters
+    ----------
+    url : `str`
+        The URL of the server to check.
+    timeout : `int`
+        Maximum time in seconds to wait for the server to respond.
+    retry_interval : `float`
+        Time in seconds to wait between retries (default: 1s).
+
+    Returns
+    -------
+    `bool`
+        `True` if the server is responsive, `False` if the timeout is reached.
+    """
+    start_time = time.time()
+    attempts = 0  # Track how many times we retry
+
+    while time.time() - start_time < timeout:
+        attempts += 1
+        try:
+            response = requests.get(url, timeout=5)
+
+            if response.status_code == 200:
+                return True
+        except Exception:
+            time.sleep(retry_interval)
+
+    display_warning(f"GOATS server did not respond after {attempts} attempts.")
+    display_warning(
+        f"Check if the server is running, then open your browser and go to: {url}"
+    )
+    return False
+
+
+def open_browser(url: str, browser_choice: str) -> None:
+    """Opens the specified browser or defaults to the system browser.
+
+    Parameters
+    ----------
+    url : `str`
+        The URL to open in the browser.
+    browser_choice : `str`
+        The browser choice.
+    """
+    display_message(f"Opening GOATS at {url} in {browser_choice} browser.")
+    try:
+        if browser_choice == "default":
+            webbrowser.open_new(url)
+        else:
+            browser = webbrowser.get(browser_choice)
+            browser.open_new(url)
+    except webbrowser.Error as e:
+        display_warning(f"Failed to open browser '{browser_choice}': {str(e)}.")
+        display_warning(f"Try opening a browser and navigate to: {url}")

--- a/tests/unit/goats_cli/test_cli.py
+++ b/tests/unit/goats_cli/test_cli.py
@@ -1,10 +1,6 @@
 import click.testing
 import pytest
 from goats_cli import cli
-import requests
-from unittest.mock import patch, MagicMock
-from goats_cli.cli import wait_until_responsive, open_browser, parse_addrport, DEFAULT_HOST
-import webbrowser
 
 
 @pytest.fixture()
@@ -15,61 +11,3 @@ def runner():
 def test_cli_succeeds_without_subcommand(runner):
     result = runner.invoke(cli)
     assert result.exit_code == 0
-import itertools
-
-
-@pytest.mark.parametrize("side_effect, expected", [
-    ([MagicMock(status_code=200)], True),  # Server is immediately responsive.
-    ([requests.exceptions.ConnectionError()] * 2 + [MagicMock(status_code=200)], True),  # Fails 2 times, then works.
-    (itertools.cycle([requests.exceptions.ConnectionError()]), False)  # Always fails.
-])
-def test_wait_until_responsive(side_effect, expected):
-    url = "http://localhost:8000"
-    with patch("requests.get", side_effect=side_effect) as mock_get:
-        result = wait_until_responsive(url, timeout=2, retry_interval=0.1)
-        assert result == expected
-
-
-@pytest.mark.parametrize("browser_choice, get_raises, expected_warning", [
-    ("default", False, None),  # Default browser opens successfully.
-    ("firefox", False, None),  # Specific browser opens successfully.
-    ("chrome", True, "Failed to open browser 'chrome'"),  # Specified browser fails.
-])
-def test_open_browser(browser_choice, get_raises, expected_warning, capsys):
-    url = "http://localhost:8000"
-    with patch("webbrowser.get") as mock_get, patch("webbrowser.open_new") as mock_open:
-        if get_raises:
-            mock_get.side_effect = webbrowser.Error("Browser not found")
-
-        open_browser(url, browser_choice)
-
-        if browser_choice == "default":
-            mock_open.assert_called_once_with(url)
-        else:
-            mock_get.assert_called_once_with(browser_choice)
-            if not get_raises:
-                mock_get.return_value.open_new.assert_called_once_with(url)
-
-        if expected_warning:
-            captured = capsys.readouterr()
-            assert expected_warning in captured.out or captured.err
-            
-
-@pytest.mark.parametrize("addrport, expected", [
-    ("localhost:8000", ("localhost", 8000)),  # Valid hostname.
-    ("127.0.0.1:8080", ("127.0.0.1", 8080)),  # Valid IP address.
-    ("0.0.0.0:5000", ("0.0.0.0", 5000)),  # Valid 0.0.0.0 binding.
-    ("8000", (DEFAULT_HOST, 8000)),  # Default host.
-])
-def test_parse_addrport_valid(addrport, expected, monkeypatch):
-    assert parse_addrport(addrport) == expected
-
-@pytest.mark.parametrize("addrport", [
-    "localhost",  # Missing port.
-    "localhost:",  # Empty port.
-    "bad_address:xyz",  # Non-numeric port.
-    ":8000",  # Missing host.
-])
-def test_parse_addrport_invalid(addrport):
-    with pytest.raises(ValueError, match=f"Invalid addrport format: '{addrport}'"):
-        parse_addrport(addrport)

--- a/tests/unit/goats_cli/test_config.py
+++ b/tests/unit/goats_cli/test_config.py
@@ -1,0 +1,15 @@
+from goats_cli.config import config, Config
+
+def test_config_addrports():
+    """Test that addrport values are generated correctly."""
+    assert config.django_addrport == "localhost:8000"
+    assert config.redis_addrport == "localhost:6379"
+
+def test_config_custom_values():
+    """Test that the Config class correctly handles custom values."""
+    cfg = Config(host="127.0.0.1", redis_port=6380, django_port=8080)
+    assert cfg.host == "127.0.0.1"
+    assert cfg.redis_port == 6380
+    assert cfg.django_port == 8080
+    assert cfg.django_addrport == "127.0.0.1:8080"
+    assert cfg.redis_addrport == "127.0.0.1:6380"

--- a/tests/unit/goats_cli/test_exceptions.py
+++ b/tests/unit/goats_cli/test_exceptions.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch, MagicMock
+import click
+from goats_cli.exceptions import GOATSClickException
+from click._compat import get_text_stderr
+
+def test_goats_click_exception_message():
+    """Test that GOATSClickException stores and formats the message correctly."""
+    exception = GOATSClickException("Something went wrong")
+    assert exception.format_message() == "Something went wrong"
+
+
+@patch("click.echo")
+def test_goats_click_exception_show(mock_echo):
+    """Test that GOATSClickException displays the error message correctly."""
+    exception = GOATSClickException("Something went wrong")
+
+    # Mock a file-like object.
+    mock_file = MagicMock()
+
+    # Call the show method.
+    exception.show(file=mock_file)
+
+    # Verify that click.echo was called with the expected formatted message.
+    mock_echo.assert_called_once_with(
+        click.style("🐐 Error: Something went wrong", fg="red", bold=True),
+        file=mock_file,
+    )
+
+
+@patch("click.echo")
+def test_goats_click_exception_show_default_file(mock_echo):
+    """Test that GOATSClickException defaults to stderr when no file is provided."""
+
+    exception = GOATSClickException("Something went wrong")
+
+    # Call the show method without passing a file.
+    exception.show()
+
+    # Verify that click.echo was called with the expected formatted message.
+    mock_echo.assert_called_once_with(
+        click.style("🐐 Error: Something went wrong", fg="red", bold=True),
+        file=get_text_stderr(),
+    )

--- a/tests/unit/goats_cli/test_utils.py
+++ b/tests/unit/goats_cli/test_utils.py
@@ -1,0 +1,179 @@
+import pytest
+import requests
+from unittest.mock import patch, MagicMock
+from goats_cli.utils import (
+    wait_until_responsive, open_browser, parse_addrport, display_message,display_ok,
+    display_info,display_failed,display_warning, port_in_use, check_port_not_in_use
+)
+import webbrowser
+import itertools
+from goats_cli.config import config
+import click
+import socket
+from goats_cli.exceptions import GOATSClickException
+
+
+class TestPortChecks:
+    """Test suite for checking port availability functions."""
+
+    @patch("socket.socket")
+    def test_port_in_use_true(self, mock_socket):
+        """Test port_in_use returns True when port is in use."""
+        mock_sock = MagicMock()
+        # 0 = port in use.
+        mock_sock.connect_ex.return_value = 0
+        mock_socket.return_value.__enter__.return_value = mock_sock
+
+        assert port_in_use("localhost", 8000) is True
+
+    @patch("socket.socket")
+    def test_port_in_use_false(self, mock_socket):
+        """Test port_in_use returns False when port is not in use."""
+        mock_sock = MagicMock()
+        # 1 = port not in use.
+        mock_sock.connect_ex.return_value = 1
+        mock_socket.return_value.__enter__.return_value = mock_sock
+
+        assert port_in_use("localhost", 8000) is False
+
+    @patch("goats_cli.utils.port_in_use", return_value=True)
+    @patch("goats_cli.utils.display_info")
+    @patch("goats_cli.utils.display_failed")
+    def test_check_port_not_in_use_raises_exception(
+        self, mock_display_failed, mock_display_info, mock_port_in_use
+    ):
+        """Test check_port_not_in_use raises an exception if port is in use."""
+        with pytest.raises(GOATSClickException, match="Django instance already running on localhost:8000."):
+            check_port_not_in_use("Django", "localhost", 8000)
+
+        mock_display_info.assert_called_once_with("Checking Django on localhost:8000...")
+        mock_display_failed.assert_called_once()
+
+    @patch("goats_cli.utils.port_in_use", return_value=False)
+    @patch("goats_cli.utils.display_info")
+    @patch("goats_cli.utils.display_ok")
+    def test_check_port_not_in_use_passes(
+        self, mock_display_ok, mock_display_info, mock_port_in_use
+    ):
+        """Test check_port_not_in_use passes when port is not in use."""
+        check_port_not_in_use("Redis", "localhost", 6379)
+
+        mock_display_info.assert_called_once_with("Checking Redis on localhost:6379...")
+        mock_display_ok.assert_called_once()
+
+
+@pytest.mark.parametrize("browser_choice, get_raises, expected_warning", [
+    ("default", False, None),  # Default browser opens successfully.
+    ("firefox", False, None),  # Specific browser opens successfully.
+    ("chrome", True, "Failed to open browser 'chrome'"),  # Specified browser fails.
+])
+def test_open_browser(browser_choice, get_raises, expected_warning, capsys):
+    url = "http://localhost:8000"
+    with patch("webbrowser.get") as mock_get, patch("webbrowser.open_new") as mock_open:
+        if get_raises:
+            mock_get.side_effect = webbrowser.Error("Browser not found")
+
+        open_browser(url, browser_choice)
+
+        if browser_choice == "default":
+            mock_open.assert_called_once_with(url)
+        else:
+            mock_get.assert_called_once_with(browser_choice)
+            if not get_raises:
+                mock_get.return_value.open_new.assert_called_once_with(url)
+
+        if expected_warning:
+            captured = capsys.readouterr()
+            assert expected_warning in captured.out or captured.err
+
+
+@pytest.mark.parametrize("side_effect, expected", [
+    ([MagicMock(status_code=200)], True),  # Server is immediately responsive.
+    ([requests.exceptions.ConnectionError()] * 2 + [MagicMock(status_code=200)], True),  # Fails 2 times, then works.
+    (itertools.cycle([requests.exceptions.ConnectionError()]), False)  # Always fails.
+])
+def test_wait_until_responsive(side_effect, expected):
+    url = "http://localhost:8000"
+    with patch("requests.get", side_effect=side_effect) as mock_get:
+        result = wait_until_responsive(url, timeout=2, retry_interval=0.1)
+        assert result == expected
+
+
+
+@pytest.mark.parametrize("addrport, expected", [
+    ("localhost:8000", ("localhost", 8000)),  # Valid hostname.
+    ("127.0.0.1:8080", ("127.0.0.1", 8080)),  # Valid IP address.
+    ("0.0.0.0:5000", ("0.0.0.0", 5000)),  # Valid 0.0.0.0 binding.
+    ("8000", (config.host, 8000)),  # Default host.
+])
+def test_parse_addrport_valid(addrport, expected, monkeypatch):
+    assert parse_addrport(addrport) == expected
+
+@pytest.mark.parametrize("addrport", [
+    "localhost",  # Missing port.
+    "localhost:",  # Empty port.
+    "bad_address:xyz",  # Non-numeric port.
+    ":8000",  # Missing host.
+])
+def test_parse_addrport_invalid(addrport):
+    with pytest.raises(ValueError, match=f"Invalid addrport format: '{addrport}'"):
+        parse_addrport(addrport)
+
+
+class TestDisplayUtils:
+    """Test suite for display utility functions."""
+
+    @patch("click.echo")
+    def test_display_message_with_emoji(self, mock_echo):
+        """Test display_message with default emoji and color."""
+        display_message("Test message")
+        mock_echo.assert_called_once_with(click.style("🐐 Test message", fg="cyan", bold=True))
+
+    @patch("click.echo")
+    def test_display_message_without_emoji(self, mock_echo):
+        """Test display_message without emoji."""
+        display_message("Test message", show_goats_emoji=False)
+        mock_echo.assert_called_once_with(click.style("Test message", fg="cyan", bold=True))
+
+    @patch("click.echo")
+    def test_display_message_custom_color(self, mock_echo):
+        """Test display_message with a custom color."""
+        display_message("Test message", color="red")
+        mock_echo.assert_called_once_with(click.style("🐐 Test message", fg="red", bold=True))
+
+    @patch("click.echo")
+    def test_display_ok(self, mock_echo):
+        """Test display_ok prints 'OK' in green."""
+        with patch("time.sleep"):  # Skip sleep for speedup
+            display_ok()
+        mock_echo.assert_called_with(click.style(" OK", fg="green", bold=True))
+
+    @patch("click.echo")
+    def test_display_info(self, mock_echo):
+        """Test display_info with default indentation."""
+        display_info("Test info")
+        mock_echo.assert_called_once_with("    Test info", nl=False)
+
+    @patch("click.echo")
+    def test_display_info_custom_indent(self, mock_echo):
+        """Test display_info with custom indentation."""
+        display_info("Test info", indent=6)
+        mock_echo.assert_called_once_with("      Test info", nl=False)
+
+    @patch("click.echo")
+    def test_display_failed(self, mock_echo):
+        """Test display_failed prints 'FAILED' in red."""
+        display_failed()
+        mock_echo.assert_called_once_with(click.style(" FAILED", fg="red", bold=True))
+
+    @patch("click.echo")
+    def test_display_warning(self, mock_echo):
+        """Test display_warning prints a warning message in yellow."""
+        display_warning("Test warning")
+        mock_echo.assert_called_once_with(click.style("🐐 WARNING: Test warning", fg="yellow", bold=True))
+
+    @patch("click.echo")
+    def test_display_warning_with_indent(self, mock_echo):
+        """Test display_warning with indentation."""
+        display_warning("Test warning", indent=4)
+        mock_echo.assert_called_once_with(click.style("🐐 WARNING:     Test warning", fg="yellow", bold=True))


### PR DESCRIPTION
- Added shutdown return codes for Redis, Django, and Dramatiq.
- Killed child workers if timeout occurs to prevent orphaned processes.
- Checked for occupied ports on startup and blocked execution if in use.

[Jira Ticket: GOATS-655](https://noirlab.atlassian.net/browse/GOATS-655)
[Jira Ticket: GOATS-656](https://noirlab.atlassian.net/browse/GOATS-656)
[Jira Ticket: GOATS-657](https://noirlab.atlassian.net/browse/GOATS-657)

## Checklist

- [X] Added or reviewed a release note in `doc/changes`.
