### PR TITLE
GOATS-678: Update to DRAGONS 4.0.0 and Python 3.12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Its objective is to simplify the TDAMM workflow for users by serving as a one-st
 For detailed information on installation, configuration, and usage, visit the **[GOATS documentation](https://goats.readthedocs.io/en/latest/)**.
 
 ## System Requirements
-- Python 3.10 or higher
+- Python 3.12 or higher
 - Intel Anaconda or Miniconda (works on M1 architecture) >= 4.12
 
 ### Workaround for ARM (M1/M2) Mac users:

--- a/ci_environment.yaml
+++ b/ci_environment.yaml
@@ -20,14 +20,10 @@ channels:
   - nodefaults
 
 dependencies:
-  - dragons=3.2.3
-  - pip
-  - python>=3.10
-  - redis-server
+  - dragons=4.0.0
+  - pip=25.1.1
+  - python=3.12
+  - redis-server=7.2.8
 
   # For development, use clone the GOATS repo and "pip install -e ." or
   # for tests, install with "pip install -e '.[test]'".
-
-  # Uncomment the below lines to install from GitHub (requires repo access).
-  - pip:
-    - git+https://github.com/gemini-hlsw/goats.git@25.3.0

--- a/docs/changes/GOATS-668.new.md
+++ b/docs/changes/GOATS-668.new.md
@@ -1,0 +1,1 @@
+Replaced Astro Data Lab client: Implemented internal class to remove dependency conflicts.

--- a/docs/changes/GOATS-678.change.md
+++ b/docs/changes/GOATS-678.change.md
@@ -1,0 +1,1 @@
+Updated DRAGONS and dependencies: Updated to DRAGONS 4.0.0 and raised the required Python version to 3.12. Also updated other dependencies for compatibility.

--- a/environment.yaml
+++ b/environment.yaml
@@ -20,10 +20,9 @@ channels:
   - nodefaults
 
 dependencies:
-  - dragons=3.2.3
-  - pip
-  - python>=3.10
-  - redis-server
-
-  # For development, use clone the GOATS repo and "pip install -e ." or
-  # for tests, install with "pip install -e '.[test]'".
+  - dragons=4.0.0
+  - pip=25.1.1
+  - python=3.12
+  - redis-server=7.2.8
+  - pip:
+    - git+https://github.com/gemini-hlsw/goats.git@25.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,22 +17,22 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
-requires-python = ">=3.10.0"
+requires-python = ">=3.12"
 dependencies = [
     "astropy>=6.0,<7",
     "astroquery==0.4.10",
-    "tomtoolkit==2.23.1",
-    "click>=8.1.7,<9",
-    "django-cors-headers>=4.3.0,<5",
+    "tomtoolkit==2.24.5",
+    "click>=8.2.1,<9",
+    "django-cors-headers>=4.7.0,<5",
     "django-cryptography>=1.1,<2",
     "channels[daphne]>=4.0,<5",
-    "channels_redis>=4.0.0,<5",
+    "channels_redis>=4.2.1,<5",
     "django>=4.2.2,<5",
-    "djangorestframework>=3.14.0,<4",
-    "dramatiq[redis, watch]>=1.17.0",
-    "django-dramatiq>=0.11.6",
-    "dramatiq-abort>=1.1.0",
-    "numpydoc>=1.7.0,<2",
+    "djangorestframework>=3.16.0,<4",
+    "dramatiq[redis, watch]>=1.18.0,<2",
+    "django-dramatiq>=0.13.0",
+    "dramatiq-abort>=1.2.1",
+    "numpydoc>=1.8.0,<2",
     "marshmallow>=3.26.1,<4",
     "marshmallow-jsonapi>=0.24.0",
 ]

--- a/src/goats_tom/static/css/cores/halfmoon.goats.css
+++ b/src/goats_tom/static/css/cores/halfmoon.goats.css
@@ -217,23 +217,23 @@ footer {
 }
 
 .shadow-xs {
-  box-shadow: 0 1px 3px hsla(0deg 0% 0% / 20%);
+  box-shadow: 0 1px 3px hsl(0deg 0% 0% / 20%);
 }
 
 .shadow-sm {
-  box-shadow: 0 4px 6px hsla(0deg 0% 0% / 20%);
+  box-shadow: 0 4px 6px hsl(0deg 0% 0% / 20%);
 }
 
 .shadow-md {
-  box-shadow: 0 5px 15px hsla(0deg 0% 0% / 20%);
+  box-shadow: 0 5px 15px hsl(0deg 0% 0% / 20%);
 }
 
 .shadow-lg {
-  box-shadow: 0 10px 24px hsla(0deg 0% 0% / 20%);
+  box-shadow: 0 10px 24px hsl(0deg 0% 0% / 20%);
 }
 
 .shadow-xl {
-  box-shadow: 0 15px 35px hsla(0deg 0% 0% / 20%);
+  box-shadow: 0 15px 35px hsl(0deg 0% 0% / 20%);
 }
 
 .download-tasks-container {


### PR DESCRIPTION
- Bumped DRAGONS to latest stable release.
- Raised required Python version to 3.12.
- Updated other dependencies for compatibility.

[Jira Ticket: GOATS-678](https://noirlab.atlassian.net/browse/GOATS-678)

## Checklist

- [X] Added or reviewed a release note in `doc/changes`.
