### PR TITLE
GOATS-681 GOATS-682: Fix macOS arch issue and update dependabot config.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # TOMToolkit limit.
+      - dependency_name: "django"
+        versions: [">=5.0.0"]
+      # ANTARES client workaround.
+      - dependency_name: "marshmallow"
+        versions: [">=4.0.0"]
+      # TOMToolkit limit.
+      - dependency_name: "astropy"
+        versions: [">=7.0.0"]
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`

--- a/.github/workflows/build_conda_env.yml
+++ b/.github/workflows/build_conda_env.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # Test building on Mac Intel as well. 
+        os: [ubuntu-latest, macos-13]
         python-version: ["3.12"]
 
     steps:
@@ -33,6 +34,7 @@ jobs:
           channels: conda-forge, http://astroconda.gemini.edu/public
           channel-priority: strict
           auto-activate-base: false
+          conda-remove-defaults: "true"
 
       - name: Get date
         id: get-date
@@ -54,12 +56,7 @@ jobs:
 
       - name: Update environment
         run: |
-          PLATFORM_ARG=""
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
-            PLATFORM_ARG="--platform osx-64"
-          fi
-
-          mamba env update -n goats-env -f goats/ci_environment.yaml $PLATFORM_ARG
+          conda env update -n goats-env -f goats/ci_environment.yaml
           cd goats
           uv pip install -v -e . --group dev
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -36,6 +36,7 @@ jobs:
           channels: conda-forge, http://astroconda.gemini.edu/public
           channel-priority: strict
           auto-activate-base: false
+          conda-remove-defaults: "true"
 
       - name: Get date
         id: get-date
@@ -57,7 +58,7 @@ jobs:
 
       - name: Update environment
         run: |
-          mamba env update -n goats-env -f goats/ci_environment.yaml
+          conda env update -n goats-env -f goats/ci_environment.yaml
           cd goats
           uv pip install -v -e . --group dev
         if: steps.cache.outputs.cache-hit != 'true'

--- a/docs/changes/GOATS-101.new.md
+++ b/docs/changes/GOATS-101.new.md
@@ -1,0 +1,1 @@
+Added `uv` for dependency management: Used `uv` to manage dependencies and generate lockfile for reproducible environments.

--- a/docs/changes/GOATS-680.new.md
+++ b/docs/changes/GOATS-680.new.md
@@ -1,0 +1,1 @@
+Enabled automated updates: Configured Dependabot to create pull requests for dependency updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "astropy>=6.0,<7",
-    "astroquery==0.4.10",
+    "astroquery>=0.4.10",
     "channels-redis>=4.2.1,<5",
     "channels[daphne]>=4.0,<5",
     "click>=8.2.1,<9",
@@ -34,7 +34,7 @@ dependencies = [
     "marshmallow>=3.26.1,<4",
     "marshmallow-jsonapi>=0.24.0",
     "numpydoc>=1.8.0,<2",
-    "tomtoolkit==2.24.5",
+    "tomtoolkit>=2.24.5",
 ]
 version = "25.6.0rc1"
 

--- a/uv.lock
+++ b/uv.lock
@@ -944,26 +944,6 @@ dependencies = [
     { name = "tomtoolkit" },
 ]
 
-[package.optional-dependencies]
-docs = [
-    { name = "sphinx" },
-    { name = "sphinx-autobuild" },
-    { name = "sphinx-rtd-theme" },
-    { name = "sphinxcontrib-video" },
-]
-test = [
-    { name = "factory-boy" },
-    { name = "nox" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-django" },
-    { name = "pytest-mock" },
-    { name = "pytest-remotedata" },
-    { name = "pytest-xdist" },
-    { name = "ruff" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "factory-boy" },
@@ -990,7 +970,7 @@ notebook = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", specifier = ">=6.0,<7" },
-    { name = "astroquery", specifier = "==0.4.10" },
+    { name = "astroquery", specifier = ">=0.4.10" },
     { name = "channels", extras = ["daphne"], specifier = ">=4.0,<5" },
     { name = "channels-redis", specifier = ">=4.2.1,<5" },
     { name = "click", specifier = ">=8.2.1,<9" },
@@ -1001,26 +981,11 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.16.0,<4" },
     { name = "dramatiq", extras = ["redis", "watch"], specifier = ">=1.18.0,<2" },
     { name = "dramatiq-abort", specifier = ">=1.2.1" },
-    { name = "factory-boy", marker = "extra == 'test'" },
     { name = "marshmallow", specifier = ">=3.26.1,<4" },
     { name = "marshmallow-jsonapi", specifier = ">=0.24.0" },
-    { name = "nox", marker = "extra == 'test'" },
     { name = "numpydoc", specifier = ">=1.8.0,<2" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytest-asyncio", marker = "extra == 'test'" },
-    { name = "pytest-cov", marker = "extra == 'test'" },
-    { name = "pytest-django", marker = "extra == 'test'" },
-    { name = "pytest-mock", marker = "extra == 'test'" },
-    { name = "pytest-remotedata", marker = "extra == 'test'" },
-    { name = "pytest-xdist", marker = "extra == 'test'" },
-    { name = "ruff", marker = "extra == 'test'" },
-    { name = "sphinx", marker = "extra == 'docs'" },
-    { name = "sphinx-autobuild", marker = "extra == 'docs'" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
-    { name = "sphinxcontrib-video", marker = "extra == 'docs'" },
-    { name = "tomtoolkit", specifier = "==2.24.5" },
+    { name = "tomtoolkit", specifier = ">=2.24.5" },
 ]
-provides-extras = ["test", "docs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
- Force conda env build to avoid arm64 on macOS and instead use Intel.
- Configure dependabot to ignore major versions for django, marshmallow, and astropy.

[Jira Ticket: GOATS-681](https://noirlab.atlassian.net/browse/GOATS-681)
[Jira Ticket: GOATS-682](https://noirlab.atlassian.net/browse/GOATS-682)

## Checklist

- [X] Added or reviewed a release note in `doc/changes`.
