### PR TITLE
GOATS-761: Hide GOA and DRAGONS section in observation for non-Gemini observations.

### DIFF
--- a/docs/changes/373.change.rst
+++ b/docs/changes/373.change.rst
@@ -1,0 +1,1 @@
+Changed the visibility of downloading from GOA and reducing data with DRAGONS for observations not associated with Gemini.

--- a/src/goats_tom/templates/tom_observations/observationrecord_detail.html
+++ b/src/goats_tom/templates/tom_observations/observationrecord_detail.html
@@ -26,8 +26,10 @@
   </div>
 </div>
 <hr class="mb-5" />
-{% render_goa_query_form %}
-{% render_launch_dragons %}
+{% if object.facility == "GEM" %}
+  {% render_goa_query_form %}
+  {% render_launch_dragons %}
+{% endif %}
 <div class="row justify-content-center">
   <div class="col-md-12">
     <h4>Saved Data Products</h4>


### PR DESCRIPTION
## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
