### PR TITLE
GOATS-832: Add dependabot groups to reduce number of PRs.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,40 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "astropy"
+          - "astroquery"
+          - "channels-redis"
+          - "channels[daphne]"
+          - "click"
+          - "django"
+          - "django-cors-headers"
+          - "django-dramatiq"
+          - "djangorestframework"
+          - "dramatiq-abort"
+          - "dramatiq[redis,watch]"
+          - "gpp-client"
+          - "marshmallow"
+          - "marshmallow-jsonapi"
+          - "numpydoc"
+          - "tom-tns"
+          - "tomtoolkit"
+      development-dependencies:
+        patterns:
+          - "pytest*"
+          - "factory-boy"
+          - "ruff"
+          - "towncrier"
+      documentation-dependencies:
+        patterns:
+          - "furo"
+          - "sphinx*"
+      notebook-dependencies:
+        patterns:
+          - "ipykernel"
     ignore:
       # TOMToolkit limit.
       - dependency-name: "django"
@@ -23,3 +56,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"

--- a/docs/changes/388.new.rst
+++ b/docs/changes/388.new.rst
@@ -1,0 +1,1 @@
+Created ``Dependabot`` groups to reduce number of PRs when updating dependencies.


### PR DESCRIPTION

## Checklist

- [ ] Added a release note in `doc/changes` using the PR number.
