### PR TITLE
GOATS-1147: LCO data downloaded and saved on GOATS not showing the full path

### DIFF
--- a/docs/changes/549.bugfix.rst
+++ b/docs/changes/549.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where LCO data downloaded and saved in GOATS did not display the full path.

--- a/src/goats_tom/templates/tom_dataproducts/dataproduct_list.html
+++ b/src/goats_tom/templates/tom_dataproducts/dataproduct_list.html
@@ -1,5 +1,5 @@
 {% extends 'tom_common/base.html' %}
-{% load bootstrap4 static cache %}
+{% load bootstrap4 static cache tom_overrides %}
 {% block title %} Data Product List {% endblock %}
 {% block additional_css %}
 <link rel="stylesheet" href="{% static 'tom_observations/css/main.css' %}">
@@ -23,6 +23,7 @@
           <th>Type</th>
         </tr>
       </thead>
+      {% define_data_product_type object_list %}
       <tbody>
         {% for product in object_list %}
         <tr>

--- a/src/goats_tom/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
+++ b/src/goats_tom/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
@@ -1,4 +1,4 @@
-{% load bootstrap4 %} {% include 'tom_dataproducts/partials/js9_scripts.html' %}
+{% load bootstrap4 tom_overrides %} {% include 'tom_dataproducts/partials/js9_scripts.html' %}
 <h4>Data</h4>
 <div class="row g-3">
   <div class="col-12">
@@ -31,6 +31,7 @@
             <th></th>
           </tr>
         </thead>
+        {% define_data_product_type products %}
         <tbody id="manageDataTBody">
           {% for product in products %}
           <tr data-file="{{ product.product_id }}">
@@ -76,7 +77,7 @@
             </td>
             <td>
               <a href="{{ product.data.url }}" target="_blank"
-                >{{ product.product_id }}</a
+                >{{ product }}</a
               >
             </td>
             <td>

--- a/src/goats_tom/templates/tom_dataproducts/partials/saved_dataproduct_list_for_observation.html
+++ b/src/goats_tom/templates/tom_dataproducts/partials/saved_dataproduct_list_for_observation.html
@@ -14,7 +14,7 @@
   <tbody>
     {% for product in products_page %}
     <tr>
-      <td><a href="{{ product.data.url }}">{{ product.product_id }}</a></td>
+      <td><a href="{{ product.data.url }}">{{ product }}</a></td>
       <td>
         {% if product.data_product_type %}
           {{ product.get_type_display }}

--- a/tests/goats_tom/templatetags/test_tom_overrides.py
+++ b/tests/goats_tom/templatetags/test_tom_overrides.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+# Adjust this to your real module path
+MODULE = "goats_tom.templatetags.tom_overrides"
+
+
+@pytest.fixture
+def mod():
+    """Import the template-tag module under test."""
+    __import__(MODULE)
+    return __import__(MODULE, fromlist=["*"])
+
+
+@dataclass
+class DummyData:
+    url: str
+
+
+@dataclass
+class DummyProduct:
+    data: Any = None
+    data_product_type: str | None = None
+
+
+def test__define_data_product_type_sets_fits_file_on_fits_fz(mod):
+    p1 = DummyProduct(data=DummyData(url="http://x/y/file.fits.fz"))
+    p2 = DummyProduct(data=DummyData(url="http://x/y/file.fits"))  # should not change
+    p3 = DummyProduct(data=DummyData(url="http://x/y/file.fits.fz"), data_product_type="already")  # preserved
+
+    out = mod._define_data_product_type([p1, p2, p3])
+
+    assert out[0].data_product_type == "fits_file"
+    assert out[1].data_product_type is None
+    assert out[2].data_product_type == "already"
+
+
+def test_define_data_product_type_tag_returns_empty_string_and_mutates(mod):
+    p = DummyProduct(data=DummyData(url="http://x/y/file.fits.fz"))
+    rendered = mod.define_data_product_type([p])
+
+    assert rendered == ""
+    assert p.data_product_type == "fits_file"
+
+
+def test_goats_dataproduct_list_for_observation_saved_paginates_and_defines_type(mocker, mod):
+    """
+    Covers:
+    - request.GET["page_saved"]
+    - pagination with page size 25
+    - _define_data_product_type called on paginator.get_page(page)
+    """
+    # 30 items ensures pagination exists
+    saved = [DummyProduct(data=DummyData(url=f"http://x/{i}.fits.fz")) for i in range(30)]
+    data_products = {"saved": saved}
+
+    request = SimpleNamespace(GET={"page_saved": "1"})
+
+    define_spy = mocker.spy(mod, "_define_data_product_type")
+
+    ctx = mod.goats_dataproduct_list_for_observation_saved(
+        data_products=data_products,
+        request=request,
+        observation_record=SimpleNamespace(pk=123),
+    )
+
+    assert "products_page" in ctx
+    assert "observation_record" in ctx
+
+    # ensure we paginated (page size is 25)
+    products_page = ctx["products_page"]
+    assert len(products_page.object_list) == 25
+
+    # ensure define was applied to the page object
+    define_spy.assert_called_once()
+    for p in products_page.object_list:
+        assert p.data_product_type == "fits_file"
+
+
+@dataclass
+class DummyDatum:
+    value: Any
+    timestamp: datetime
+
+
+class DummyQS(list):
+    """A minimal chainable queryset-like object."""
+    def filter(self, **kwargs):
+        # For test purposes, return self (or you can implement filtering if you want)
+        return self
+
+
+def _make_deserialized():
+    # SpectrumSerializer().deserialize(datum.value) returns an object with:
+    #   .wavelength.value and .flux.value
+    return SimpleNamespace(
+        wavelength=SimpleNamespace(value=[1, 2, 3]),
+        flux=SimpleNamespace(value=[10, 20, 30]),
+    )
+
+
+def test_spectroscopy_for_target_permissions_only_true_uses_base_query(mocker, mod, settings):
+    """
+    Covers:
+    - settings.TARGET_PERMISSIONS_ONLY True branch
+    - ReducedDatum.objects.filter(...) used
+    - get_objects_for_user NOT called
+    - offline.plot called and returned into context["plot"]
+    """
+    settings.TARGET_PERMISSIONS_ONLY = True
+
+    # Patch ReducedDatum.objects.filter(...) to return a chainable QS of datums
+    datums = DummyQS(
+        [
+            DummyDatum(value={"raw": 1}, timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc)),
+            DummyDatum(value={"raw": 2}, timestamp=datetime(2025, 1, 2, tzinfo=timezone.utc)),
+        ]
+    )
+    mocker.patch(f"{MODULE}.ReducedDatum.objects.filter", return_value=datums)
+
+    get_objs = mocker.patch(f"{MODULE}.get_objects_for_user")
+    # Avoid real plotly
+    mocker.patch(f"{MODULE}.offline.plot", return_value="<div>plot</div>")
+    # Avoid real deserialization
+    deserialize = mocker.patch(f"{MODULE}.SpectrumSerializer.deserialize", return_value=_make_deserialized())
+
+    context = {"request": SimpleNamespace(user=SimpleNamespace())}
+    target = SimpleNamespace(pk=1)
+
+    out = mod.spectroscopy_for_target(context, target, dataproduct=None)
+
+    assert out["target"] is target
+    assert out["plot"] == "<div>plot</div>"
+
+    get_objs.assert_not_called()
+    assert deserialize.call_count == 2
+
+
+def test_spectroscopy_for_target_permissions_only_false_uses_get_objects_for_user(mocker, mod, settings):
+    """
+    Covers:
+    - settings.TARGET_PERMISSIONS_ONLY False branch
+    - get_objects_for_user called with correct permission and klass=base_query
+    """
+    settings.TARGET_PERMISSIONS_ONLY = False
+
+    base_query = DummyQS(
+        [DummyDatum(value={"raw": 1}, timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc))]
+    )
+
+    # ReducedDatum.objects.filter(...) returns base_query; later get_objects_for_user(...) returns datums to iterate
+    mocker.patch(f"{MODULE}.ReducedDatum.objects.filter", return_value=base_query)
+
+    datums = DummyQS(
+        [DummyDatum(value={"raw": 9}, timestamp=datetime(2025, 2, 1, tzinfo=timezone.utc))]
+    )
+    get_objs = mocker.patch(f"{MODULE}.get_objects_for_user", return_value=datums)
+
+    mocker.patch(f"{MODULE}.offline.plot", return_value="<div>plot</div>")
+    mocker.patch(f"{MODULE}.SpectrumSerializer.deserialize", return_value=_make_deserialized())
+
+    user = SimpleNamespace(username="u")
+    context = {"request": SimpleNamespace(user=user)}
+    target = SimpleNamespace(pk=1)
+
+    out = mod.spectroscopy_for_target(context, target, dataproduct=None)
+
+    assert out["plot"] == "<div>plot</div>"
+    get_objs.assert_called_once()
+    args, kwargs = get_objs.call_args
+    assert args[0] is user
+    assert args[1] == "tom_dataproducts.view_reduceddatum"
+    assert kwargs["klass"] is base_query
+
+
+def test_spectroscopy_for_target_filters_by_dataproduct_when_provided(mocker, mod, settings):
+    """
+    Covers:
+    - if dataproduct: base_query = base_query.filter(data_product=dataproduct)
+    """
+    settings.TARGET_PERMISSIONS_ONLY = True
+
+    base_query = DummyQS(
+        [DummyDatum(value={"raw": 1}, timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc))]
+    )
+
+    filter_mock = mocker.Mock(return_value=base_query)
+    # Make the first filter call return an object with a .filter for the dataproduct clause
+    first_qs = SimpleNamespace(filter=filter_mock)
+    mocker.patch(f"{MODULE}.ReducedDatum.objects.filter", return_value=first_qs)
+
+    mocker.patch(f"{MODULE}.offline.plot", return_value="<div>plot</div>")
+    mocker.patch(f"{MODULE}.SpectrumSerializer.deserialize", return_value=_make_deserialized())
+
+    context = {"request": SimpleNamespace(user=SimpleNamespace())}
+    target = SimpleNamespace(pk=1)
+    dataproduct = SimpleNamespace(pk=99)
+
+    out = mod.spectroscopy_for_target(context, target, dataproduct=dataproduct)
+
+    assert out["plot"] == "<div>plot</div>"
+    filter_mock.assert_called_once_with(data_product=dataproduct)
+


### PR DESCRIPTION
## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
