### PR TITLE
GOATS-1249: Fix missing f-prefix in share_title f-string

### DIFF
--- a/docs/changes/600.bugfix.rst
+++ b/docs/changes/600.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed missing f-prefix in share_title f-string that caused the share title to display incorrectly.

--- a/src/goats_tom/templatetags/tom_overrides.py
+++ b/src/goats_tom/templatetags/tom_overrides.py
@@ -167,8 +167,8 @@ def get_photometry_data(context, target, target_share=False):
         "submitter": context["request"].user,
         "target": target,
         "data_type": "photometry",
-        "share_title": f"Updated data for {target.name} from"
-        "{getattr(settings, 'TOM_NAME', 'TOM Toolkit')}.",
+        "share_title": f"Updated data for {target.name} from "
+        f"{getattr(settings, 'TOM_NAME', 'TOM Toolkit')}.",
     }
     form = DataShareForm(initial=initial)
     form.fields["data_type"].widget = forms.HiddenInput()


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
