### PR TITLE
GOATS-1272: Add Django 5 compatibility to tests while maintaining Djngo 4 support

### DIFF
--- a/tests/goats_tom/templatetags/test_tom_overrides.py
+++ b/tests/goats_tom/templatetags/test_tom_overrides.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 from django.template import Context, Template
-from django.utils import timezone
+from datetime import datetime, timedelta, timezone
 from tom_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 
@@ -278,7 +278,7 @@ def test_spectroscopy_for_target_filters_by_dataproduct_when_provided(
 def test_goats_recent_photometry_limit_flag(target, values, expected_limits):
     from goats_tom.templatetags.tom_overrides import goats_recent_photometry
 
-    now = timezone.now()
+    now = datetime.now(tz=timezone.utc)
     for i, value in enumerate(values):
         ReducedDatum.objects.create(
             target=target,
@@ -304,7 +304,7 @@ def test_goats_recent_photometry_limit_flag(target, values, expected_limits):
 def test_goats_recent_photometry_respects_limit(target, total, limit, expected_count):
     from goats_tom.templatetags.tom_overrides import goats_recent_photometry
 
-    now = timezone.now()
+    now = datetime.now(tz=timezone.utc)
     for i in range(total):
         ReducedDatum.objects.create(
             target=target,
@@ -322,7 +322,7 @@ def test_goats_recent_photometry_renders_template(target, expected_string):
     ReducedDatum.objects.create(
         target=target,
         data_type="photometry",
-        timestamp=timezone.now(),
+        timestamp=datetime.now(tz=timezone.utc),
         value={"magnitude": 18.5, "filter": "i"},
         source_name="ANTARES",
     )

--- a/tests/goats_tom/utils/test_utils.py
+++ b/tests/goats_tom/utils/test_utils.py
@@ -29,7 +29,8 @@ class DeleteAssociatedDataProductsTest(TestCase):
             target_id=self.target.id,
         )
         self.data_products = DataProductFactory.create_batch(
-            3, observation_record=self.observation_record,
+            3,
+            observation_record=self.observation_record,
         )
         for data_product in self.data_products:
             ReducedDatumFactory.create(data_product=data_product)
@@ -45,16 +46,19 @@ class DeleteAssociatedDataProductsTest(TestCase):
         )
         for data_product in self.data_products:
             self.assertEqual(
-                ReducedDatum.objects.filter(data_product=data_product).count(), 0,
+                ReducedDatum.objects.filter(data_product=data_product).count(),
+                0,
             )
 
     def test_delete_single_data_product(self):
         single_data_product = self.data_products[0]
+        pk = single_data_product.pk
         delete_associated_data_products(single_data_product)
 
-        self.assertFalse(DataProduct.objects.filter(pk=single_data_product.pk).exists())
+        self.assertFalse(DataProduct.objects.filter(pk=pk).exists())
         self.assertEqual(
-            ReducedDatum.objects.filter(data_product=single_data_product).count(), 0,
+            ReducedDatum.objects.filter(data_product_id=pk).count(),
+            0,
         )
 
     def test_delete_file_and_thumbnail(self):
@@ -70,7 +74,8 @@ class DeleteAssociatedDataProductsTest(TestCase):
         # Check if files and thumbnails are deleted from the disk.
         for data_path, thumbnail_path in file_paths:
             self.assertFalse(
-                os.path.exists(data_path), f"Data file {data_path} should be deleted.",
+                os.path.exists(data_path),
+                f"Data file {data_path} should be deleted.",
             )
             self.assertFalse(
                 os.path.exists(thumbnail_path),
@@ -90,7 +95,8 @@ class BuildJsonResponseTests(unittest.TestCase):
         response = build_json_response()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            response.content.decode(), '{"status": "success", "message": ""}',
+            response.content.decode(),
+            '{"status": "success", "message": ""}',
         )
 
     def test_error_response_with_custom_message(self):
@@ -108,7 +114,8 @@ class BuildJsonResponseTests(unittest.TestCase):
         error_message = "Not found"
         error_status = status.HTTP_404_NOT_FOUND
         response = build_json_response(
-            error_message=error_message, error_status=error_status,
+            error_message=error_message,
+            error_status=error_status,
         )
         self.assertEqual(response.status_code, error_status)
         self.assertEqual(
@@ -123,7 +130,8 @@ class BuildJsonResponseTests(unittest.TestCase):
         error_message = "Unauthorized access"
         error_status = status.HTTP_401_UNAUTHORIZED
         response = build_json_response(
-            error_message=error_message, error_status=error_status,
+            error_message=error_message,
+            error_status=error_status,
         )
         self.assertEqual(response.status_code, error_status)
         self.assertEqual(
@@ -135,7 +143,8 @@ class BuildJsonResponseTests(unittest.TestCase):
 @pytest.fixture()
 def non_empty_file_list():
     return Table(
-        rows=[("file1", "red1"), ("file2", "red2")], names=("name", "reduction"),
+        rows=[("file1", "red1"), ("file2", "red2")],
+        names=("name", "reduction"),
     )
 
 

--- a/tests/goats_tom/views/test_observation_record_delete.py
+++ b/tests/goats_tom/views/test_observation_record_delete.py
@@ -34,9 +34,11 @@ class TestObservationRecordDeleteView(TestCase):
         DataProductFactory(observation_record=self.observation_record)
 
     def test_form_valid(self):
+        observation_record_pk = self.observation_record.pk
+
         # Ensure the ObservationRecord and DataProducts exist.
         self.assertIsNotNone(
-            ObservationRecord.objects.filter(pk=self.observation_record.pk).first(),
+            ObservationRecord.objects.filter(pk=observation_record_pk).first(),
         )
         self.assertEqual(
             DataProduct.objects.filter(
@@ -50,7 +52,7 @@ class TestObservationRecordDeleteView(TestCase):
         request.user = self.user
         view = ObservationRecordDeleteView()
         view.request = request
-        view.kwargs = {"pk": self.observation_record.pk}
+        view.kwargs = {"pk": observation_record_pk}
         view.object = self.observation_record
 
         # Call the form_valid method
@@ -58,12 +60,12 @@ class TestObservationRecordDeleteView(TestCase):
 
         # Test that the ObservationRecord is deleted.
         with pytest.raises(ObservationRecord.DoesNotExist):
-            ObservationRecord.objects.get(pk=self.observation_record.pk)
+            ObservationRecord.objects.get(pk=observation_record_pk)
 
         # Test that associated DataProducts are deleted
         self.assertEqual(
             DataProduct.objects.filter(
-                observation_record=self.observation_record,
+                observation_record_id=observation_record_pk,
             ).count(),
             0,
         )


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
