### PR TITLE
GOATS-1256: Fix spectrum visualizer fill appearing in light mode

### DIFF
--- a/docs/changes/619.bugfix.rst
+++ b/docs/changes/619.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed spectrum visualizer fill appearing incorrectly in light mode

--- a/src/goats_tom/templates/tom_targets/target_detail.html
+++ b/src/goats_tom/templates/tom_targets/target_detail.html
@@ -262,8 +262,6 @@
         x: wavelength,
         y: flux,
         mode: "lines",
-        fill: "tozeroy",
-        fillcolor: "rgba(100, 149, 237, 0.08)",
         line: { width: 1.5 },
         name: new Date(timestamp).toISOString(),
       });


### PR DESCRIPTION

## Checklist

- [ ] Added a release note in `doc/changes` using the PR number.
