### PR TITLE
GOATS-1287: Auto-ingest processed calibration files from archive in Dragons app

### DIFF
--- a/docs/changes/620.new.rst
+++ b/docs/changes/620.new.rst
@@ -1,0 +1,1 @@
+Added auto-ingestion of processed calibration files from the archive in the Dragons app

--- a/src/goats_tom/api_views/dragons_runs.py
+++ b/src/goats_tom/api_views/dragons_runs.py
@@ -153,6 +153,10 @@ class DRAGONSRunsViewSet(
                 logger.debug("Adding BPM to calibration database.")
                 cal_db.add_cal(data_product.data.path)
                 continue
+            if "PROCESSED" in tags and "CAL" in tags:
+                logger.debug("Adding procssed cal to calibration database.")
+                cal_db.add_cal(data_product.data.path)
+                continue
             if data_product.metadata.processed:
                 logger.debug("Skipping prepared or processed file.")
                 continue


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
