### PR TITLE
GOATS-1085: Make notification show the correct observation ID when downloading

### DIFF
--- a/docs/changes/645.bugfix.rst
+++ b/docs/changes/645.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed notification showing incorrect observation ID when downloading.

--- a/src/goats_tom/tasks/download_goa_files.py
+++ b/src/goats_tom/tasks/download_goa_files.py
@@ -83,7 +83,7 @@ def download_goa_files(
             raise
         target = observation_record.target
         facility = observation_record.facility
-        observation_id = observation_record.observation_id
+        observation_id = query_params.get("kwargs").get("progid")
         logger.debug(
             "Using Observation record: target=%s, facility=%s, observation id=%s",
             target,


### PR DESCRIPTION

## Checklist

- [ ] Added a release note in `doc/changes` using the PR number.
