### PR TITLE
GOATS-1306: Update GPP client to 26.4.1dev1 for GMOS imaging compatibility

### DIFF
--- a/docs/changes/647.change.rst
+++ b/docs/changes/647.change.rst
@@ -1,0 +1,1 @@
+Updated GPP client to 26.4.1dev1 for GMOS imaging compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "djangorestframework>=3.16.1,<4",
     "dramatiq-abort>=1.2.1",
     "dramatiq[redis,watch]>=1.18.0,<2",
-    "gpp-client==26.4.0",
+    "gpp-client==26.4.1.dev1",
     "marshmallow==3.26.2",
     "marshmallow-jsonapi>=0.24.0",
     "numpydoc>=1.9.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -1540,7 +1540,7 @@ requires-dist = [
     { name = "djangorestframework", specifier = ">=3.16.1,<4" },
     { name = "dramatiq", extras = ["redis", "watch"], specifier = ">=1.18.0,<2" },
     { name = "dramatiq-abort", specifier = ">=1.2.1" },
-    { name = "gpp-client", specifier = "==26.4.0" },
+    { name = "gpp-client", specifier = "==26.4.1.dev1" },
     { name = "marshmallow", specifier = "==3.26.2" },
     { name = "marshmallow-jsonapi", specifier = ">=0.24.0" },
     { name = "numpydoc", specifier = ">=1.9.0,<2" },
@@ -1578,7 +1578,7 @@ notebook = [{ name = "ipykernel", specifier = ">=7.2.0" }]
 
 [[package]]
 name = "gpp-client"
-version = "26.4.0"
+version = "26.4.1.dev1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1590,9 +1590,9 @@ dependencies = [
     { name = "typer" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/c5/ccf696271ed18e70ccf76ab5f2f4637dc33aac340fff94d32a4d7aaa56ce/gpp_client-26.4.0.tar.gz", hash = "sha256:08a2eb9361312ef247891aca9b99de93e181236b05518a1f690c7278077ef2ff", size = 167379, upload-time = "2026-04-14T21:54:28.852Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/5f/4750c23281acb3313f4e38dd94f121bccc51df1a9eae5cd45c7557f9a951/gpp_client-26.4.1.dev1.tar.gz", hash = "sha256:3896a873c63449977a65f549f8ddbcfc7688efb29729ca6ff46c01f0908fb464", size = 174012, upload-time = "2026-04-28T18:56:05.422Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/0a/c75f43c8b40e76ae19ade0326293d2ff65dd1bda4c9e9cf39af2545dbd49/gpp_client-26.4.0-py3-none-any.whl", hash = "sha256:7d611887edd2a59f3a27c63ff794c4fd1edaec0d1e33f7e5e573043a5163f3c8", size = 203505, upload-time = "2026-04-14T21:54:27.311Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/ae4666c97e57a76296b5bde0b4aaab6e18483a36736805f653ed3b159485/gpp_client-26.4.1.dev1-py3-none-any.whl", hash = "sha256:b0363e140f5165113ac7052e2d477e17ca7e557773a1bbf7900c94a4c5a95ecd", size = 209506, upload-time = "2026-04-28T18:56:03.796Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
