### PR TITLE
GOATS-1313 Fix logout broken by Django upgrade

### DIFF
--- a/docs/changes/653.bugfix.rst
+++ b/docs/changes/653.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed logout broken by the Django upgrade.

--- a/src/goats_tom/templates/navbar.html
+++ b/src/goats_tom/templates/navbar.html
@@ -75,7 +75,10 @@
           <a class="dropdown-item" href="{% url 'user-list' %}">Users</a>
           <a class="dropdown-item" href="{% url 'user-update' user.id %}">Settings</a>
           <div class="dropdown-divider"></div>
-          <a class="dropdown-item" href="{% url 'logout' %}">Logout</a>
+          <form method="post" action="{% url 'logout' %}" class="d-inline">
+            {% csrf_token %}
+            <button type="submit" class="dropdown-item">Logout</button>
+          </form>
         </div>
       </li>
       <li class="nav-item">


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
