### PR TITLE
GOATS-1319: Fix DataProduct metadata missing error when creating a DRAGONS run

### DIFF
--- a/docs/changes/658.bugfix.rst
+++ b/docs/changes/658.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed missing DataProduct metadata error when creating a DRAGONS run

--- a/src/goats_tom/api_views/dragons_runs.py
+++ b/src/goats_tom/api_views/dragons_runs.py
@@ -157,7 +157,9 @@ class DRAGONSRunsViewSet(
                 logger.debug("Adding procssed cal to calibration database.")
                 cal_db.add_cal(data_product.data.path)
                 continue
-            if data_product.metadata.processed:
+
+            metadata = getattr(data_product, "metadata", None)
+            if metadata and metadata.processed:
                 logger.debug("Skipping prepared or processed file.")
                 continue
 


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
