### PR TITLE
GOATS-1127: Allow multiple GPP app accordion sections to be open simultaneously

### DIFF
--- a/docs/changes/665.change.rst
+++ b/docs/changes/665.change.rst
@@ -1,0 +1,1 @@
+Allowed multiple GPP app accordion sections to be open simultaneously

--- a/src/goats_tom/static/js/gpp/observation_form.js
+++ b/src/goats_tom/static/js/gpp/observation_form.js
@@ -274,7 +274,6 @@ class ObservationForm {
 
     const body = Utils.createElement("div", bodyClasses);
     body.id = collapseId;
-    body.setAttribute("data-bs-parent", "#profile-accordion");
 
     const setExpandedState = (expanded) => {
       toggleBtn.setAttribute("aria-expanded", String(expanded));


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
