### PR TITLE
GOATS-1332: Fix GPP client environment defaulting to development instead of production

### DIFF
--- a/docs/changes/666.bugfix.rst
+++ b/docs/changes/666.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed GPP client environment defaulting to development instead of production

--- a/src/goats_cli/goats_template/{{ project_name }}/settings/__init__.py.jinja
+++ b/src/goats_cli/goats_template/{{ project_name }}/settings/__init__.py.jinja
@@ -25,7 +25,7 @@ in the following sequence:
 4. environments/<env>.py
       - Optional environment-specific overrides.
       - Selected using the GOATS_ENV environment variable.
-      - Defaults to "development".
+      - Defaults to "production".
 
 5. local.py
       - User overrides.
@@ -46,7 +46,7 @@ import os
 from .base import *
 
 # Determine GOATS environment.
-env = os.getenv("GOATS_ENV", "development").lower()
+env = os.getenv("GOATS_ENV", "production").lower()
 
 try:
     if env == "development":

--- a/src/goats_cli/goats_template/{{ project_name }}/settings/base.py.jinja
+++ b/src/goats_cli/goats_template/{{ project_name }}/settings/base.py.jinja
@@ -435,8 +435,9 @@ slow."""
 # Set the GPP environment (DEVELOPMENT, STAGING, or PRODUCTION)
 GPP_ENV = "PRODUCTION"
 
-# Set the ANATARES environment (DEVELOPMENT or PRODUCTION).
+# Set the ANTARES environment (DEVELOPMENT or PRODUCTION).
 ANTARES_ENV = "PRODUCTION"
 
 ANTARES_TIMEOUT = 60 # Timeout for requests to ANTARES in seconds.
+
 


### PR DESCRIPTION


## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
