### PR TITLE
GOATS-1128: Make GPP app form read-only when observation state is complete or ongoing

### DIFF
--- a/docs/changes/667.change.rst
+++ b/docs/changes/667.change.rst
@@ -1,0 +1,1 @@
+Made the GPP app form read-only when the observation state is complete or ongoing

--- a/src/goats_tom/static/js/gpp/gpp.js
+++ b/src/goats_tom/static/js/gpp/gpp.js
@@ -423,11 +423,15 @@ class GPPView {
     const hasProposalStatus = Boolean(observation?.proposalStatus);
     const hasMode = Boolean(observation?.scienceRequirements?.mode);
     const isCalibration = !hasMode && !hasProposalStatus;
+    const isLocked =
+      observation?.workflow?.value?.state === "COMPLETED" ||
+      observation?.workflow?.value?.state === "ONGOING";
 
+    this.#poPanel.toggleUpdateButton(isCalibration || isLocked);
     this.#form = new ObservationForm(this.#formContainer, {
       observation: observation,
       mode: "normal",
-      readOnly: isCalibration,
+      readOnly: isCalibration || isLocked,
       callbacks: this.#buildObservationFormCallbacks(),
     });
   }
@@ -438,10 +442,14 @@ class GPPView {
    * @private
    */
   #updateTooObservation(observation) {
+    const isLocked =
+      observation?.workflow?.value?.state === "COMPLETED" ||
+      observation?.workflow?.value?.state === "ONGOING";
+
     this.#form = new ObservationForm(this.#formContainer, {
       observation: observation,
       mode: "too",
-      readOnly: false,
+      readOnly: isLocked,
       callbacks: this.#buildObservationFormCallbacks(),
     });
   }

--- a/src/goats_tom/static/js/gpp/program_observations_panel.js
+++ b/src/goats_tom/static/js/gpp/program_observations_panel.js
@@ -190,6 +190,14 @@ class ProgramObservationsPanel {
     this.#logDebug(`ToO select disabled: ${disabled}`);
   }
   /**
+   * Enable or disable only the Update button.
+   * @param {boolean} disabled
+   */
+  toggleUpdateButton(disabled) {
+    this.#updateButton.disabled = disabled;
+    this.#logDebug(`Update button disabled: ${disabled}`);
+  }
+  /**
    * Enable or disable the ToO toolbar buttons.
    * @param {boolean} disabled
    */


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
