### PR TITLE
GOATS-1348: Fix for code scanning alert no. 19: Client-side cross-site scripting

### DIFF
--- a/docs/changes/678.bugfix.rst
+++ b/docs/changes/678.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a potential client-side cross-site scripting (XSS) vulnerability (code scanning alert #19)

--- a/src/goats_tom/static/js/download_progress.js
+++ b/src/goats_tom/static/js/download_progress.js
@@ -33,43 +33,85 @@ const updateNavbarDownloadLink = (activeDownloads) => {
  *
  * @param {Object} downloadProgress - The download progress information.
  */
+const sanitizeDomId = (value) => String(value || "").replace(/[^A-Za-z0-9\-_:.]/g, "_");
+
 const updateDownloadProgress = (downloadProgress) => {
   const container = document.getElementById("downloadTasksBanner");
-  let downloadItem = document.getElementById(downloadProgress.unique_id);
+  const safeUniqueId = sanitizeDomId(downloadProgress.unique_id);
+  let downloadItem = document.getElementById(safeUniqueId);
 
   // If the item doesn't exist, create it.
   if (!downloadItem) {
     downloadItem = document.createElement("div");
-    downloadItem.setAttribute("id", downloadProgress.unique_id);
+    downloadItem.setAttribute("id", safeUniqueId);
     downloadItem.setAttribute("class", "row align-items-center");
-    downloadItem.innerHTML = `
-      <div class="col-auto">
-        <i class="fa-solid fa-file-arrow-down fa-2xl text-light"></i>
-      </div>
-      <div class="col">
-        <p class="fw-bold text-muted mb-0">${downloadProgress.label}</p>
-        <div class="progress" aria-label="Downloading" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" role="status">
-          <div id="${downloadProgress.unique_id}-progressBar" class="progress-bar placeholder-wave text-bg-primary" style="width: 100%"></div>
-        </div>
-        <div class="row justify-content-between">
-          <div class="col-auto">
-            <small id="${downloadProgress.unique_id}-downloadedBytes">${downloadProgress.downloaded_bytes}</small>
-          </div>
-          <div class="col-auto">
-            <small id="${downloadProgress.unique_id}-status">${downloadProgress.status}</small>
-          </div>
-        </div>
-      </div>
-      <div class="dropdown-divider"></div>
-    `;
+
+    const iconCol = document.createElement("div");
+    iconCol.className = "col-auto";
+    const icon = document.createElement("i");
+    icon.className = "fa-solid fa-file-arrow-down fa-2xl text-light";
+    iconCol.appendChild(icon);
+
+    const contentCol = document.createElement("div");
+    contentCol.className = "col";
+
+    const labelP = document.createElement("p");
+    labelP.className = "fw-bold text-muted mb-0";
+    labelP.textContent = downloadProgress.label || "";
+
+    const progress = document.createElement("div");
+    progress.className = "progress";
+    progress.setAttribute("aria-label", "Downloading");
+    progress.setAttribute("aria-valuenow", "100");
+    progress.setAttribute("aria-valuemin", "0");
+    progress.setAttribute("aria-valuemax", "100");
+    progress.setAttribute("role", "status");
+
+    const progressBar = document.createElement("div");
+    progressBar.id = `${safeUniqueId}-progressBar`;
+    progressBar.className = "progress-bar placeholder-wave text-bg-primary";
+    progressBar.style.width = "100%";
+    progress.appendChild(progressBar);
+
+    const row = document.createElement("div");
+    row.className = "row justify-content-between";
+
+    const downloadedCol = document.createElement("div");
+    downloadedCol.className = "col-auto";
+    const downloadedBytesSmall = document.createElement("small");
+    downloadedBytesSmall.id = `${safeUniqueId}-downloadedBytes`;
+    downloadedBytesSmall.textContent = downloadProgress.downloaded_bytes || "";
+    downloadedCol.appendChild(downloadedBytesSmall);
+
+    const statusCol = document.createElement("div");
+    statusCol.className = "col-auto";
+    const statusSmall = document.createElement("small");
+    statusSmall.id = `${safeUniqueId}-status`;
+    statusSmall.textContent = downloadProgress.status || "";
+    statusCol.appendChild(statusSmall);
+
+    row.appendChild(downloadedCol);
+    row.appendChild(statusCol);
+
+    contentCol.appendChild(labelP);
+    contentCol.appendChild(progress);
+    contentCol.appendChild(row);
+
+    const divider = document.createElement("div");
+    divider.className = "dropdown-divider";
+
+    downloadItem.appendChild(iconCol);
+    downloadItem.appendChild(contentCol);
+    downloadItem.appendChild(divider);
+
     container.prepend(downloadItem);
   } else {
     // If the item exists, update its details.
     const downloadedBytesSmall = document.getElementById(
-      `${downloadProgress.unique_id}-downloadedBytes`
+      `${safeUniqueId}-downloadedBytes`
     );
     downloadedBytesSmall.textContent = downloadProgress.downloaded_bytes || "";
-    const statusSmall = document.getElementById(`${downloadProgress.unique_id}-status`);
+    const statusSmall = document.getElementById(`${safeUniqueId}-status`);
     if (downloadProgress.status !== null) {
       statusSmall.textContent = downloadProgress.status;
     }
@@ -77,7 +119,7 @@ const updateDownloadProgress = (downloadProgress) => {
     // Update the progress bar if done.
     if (downloadProgress.error) {
       const progressBarDiv = document.getElementById(
-        `${downloadProgress.unique_id}-progressBar`
+        `${safeUniqueId}-progressBar`
       );
       progressBarDiv.classList.replace("text-bg-primary", "text-bg-danger");
       progressBarDiv.classList.remove("placeholder-wave");
@@ -88,7 +130,7 @@ const updateDownloadProgress = (downloadProgress) => {
       }, 5000);
     } else if (downloadProgress.done) {
       const progressBarDiv = document.getElementById(
-        `${downloadProgress.unique_id}-progressBar`
+        `${safeUniqueId}-progressBar`
       );
       progressBarDiv.classList.replace("text-bg-primary", "text-bg-secondary");
       progressBarDiv.classList.remove("placeholder-wave");


### PR DESCRIPTION
Potential fix for [https://github.com/gemini-hlsw/goats/security/code-scanning/19](https://github.com/gemini-hlsw/goats/security/code-scanning/19)

General fix: avoid writing untrusted data with `innerHTML`; build DOM nodes with `document.createElement` and assign untrusted text via `textContent`. Also avoid unsafe IDs from untrusted input by constraining/sanitizing identifier values used in `id` and selector lookups.

Best fix here (without changing behavior): in `src/goats_tom/static/js/download_progress.js`, replace the `innerHTML` template block in `updateDownloadProgress` with explicit DOM construction. Add a small helper to sanitize `unique_id` for safe DOM id usage, and ensure all displayed untrusted fields are written with `textContent`. Keep classes/structure identical so UI behavior remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
