### PR TITLE
GOATS-1348: Fix for code scanning alert no. 20: Client-side cross-site scripting

### DIFF
--- a/docs/changes/679.bugfix.rst
+++ b/docs/changes/679.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a potential client-side cross-site scripting (XSS) vulnerability (code scanning alert #20)

--- a/src/goats_tom/static/js/toast_manager.js
+++ b/src/goats_tom/static/js/toast_manager.js
@@ -105,7 +105,7 @@ class ToastManager {
 
     const text = document.createElement("p");
     text.classList.add("mb-0");
-    text.innerHTML = message;
+    text.textContent = String(message ?? "");
     body.appendChild(text);
 
     toast.appendChild(header);


### PR DESCRIPTION
Potential fix for [https://github.com/gemini-hlsw/goats/security/code-scanning/20](https://github.com/gemini-hlsw/goats/security/code-scanning/20)

The general fix is to ensure untrusted content is added as text, not HTML. In DOM terms, use `textContent` (or `createTextNode`) instead of `innerHTML` for user-controlled values.

Best single fix without changing intended functionality: in `src/goats_tom/static/js/toast_manager.js`, replace the assignment `text.innerHTML = message;` with a safe text assignment that coerces to string, e.g. `text.textContent = String(message ?? "");`. This preserves display of message content while preventing HTML/script execution.

No changes are required in `base.html` for this specific sink fix, because the dangerous operation is in `toast_manager.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
