### PR TITLE
GOATS-1382: Fix color scheme regression in light curve photometry data

### DIFF
--- a/docs/changes/701.bugfix.rst
+++ b/docs/changes/701.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed color scheme regression in the light curve photometry data display

--- a/src/goats_tom/templates/tom_targets/target_detail.html
+++ b/src/goats_tom/templates/tom_targets/target_detail.html
@@ -306,7 +306,7 @@
 
     Object.keys(photometryData).forEach((filter) => {
       const { time, magnitude, error, limit } = photometryData[filter];
-      const color = colorMap[filter] || null;
+      const color = colorMap[filter[0]] || null;
 
       // --- Detection trace ---
       const detectionName = `${filter} detection`;


### PR DESCRIPTION

## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
