### PR TITLE
GOATS-1389: Fix light curve CSV file getting unwanted suffix on photometry update

### DIFF
--- a/docs/changes/706.bugfix.rst
+++ b/docs/changes/706.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed light curve CSV file getting an unwanted suffix when updating photometry

--- a/src/goats_tom/brokers/antares.py
+++ b/src/goats_tom/brokers/antares.py
@@ -460,6 +460,8 @@ class ANTARESBroker(GenericBroker):
         except IntegrityError:
             dp = DataProduct.objects.get(product_id=product_id)
 
+        if dp.data:
+            dp.data.delete(save=False)
         dp.data.save(file_name, data, save=True)
         return dp
 


### PR DESCRIPTION


## Checklist

- [x] Added a release note in `doc/changes` using the PR number.
